### PR TITLE
fix: enable Docker BuildKit

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -118,4 +118,5 @@ jobs:
                       EOF
 
                       git pull origin main
+                      export DOCKER_BUILDKIT=1
                       docker compose up --build -d


### PR DESCRIPTION
Re-adding BuildKit export that was lost in merge.