### PR TITLE
Add rooms backend: model, REST endpoints, WebSocket, Alembic migrations

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -28,10 +28,12 @@ ENV PATH="/app/.venv/bin:$PATH"
 # Reset the entrypoint, don't invoke `uv`
 ENTRYPOINT []
 
+RUN chmod +x /app/entrypoint.sh
+
 # Setup a non-root user
 RUN groupadd --system --gid 999 nonroot \
     && useradd --system --gid 999 --uid 999 --create-home nonroot
 USER nonroot
 
-# Run the application using uvicorn directly (avoiding uv run at runtime)
-CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]
+# Run migrations then start the app
+CMD ["/app/entrypoint.sh"]

--- a/backend/alembic.ini
+++ b/backend/alembic.ini
@@ -1,0 +1,37 @@
+[alembic]
+script_location = alembic
+prepend_sys_path = .
+
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+qualname =
+
+[logger_sqlalchemy]
+level = WARN
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s
+datefmt = %H:%M:%S

--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -1,0 +1,67 @@
+import os
+from logging.config import fileConfig
+from pathlib import Path
+
+from dotenv import load_dotenv
+from sqlalchemy import engine_from_config, pool
+
+from alembic import context
+
+# Load .env from project root if it exists
+env_path = Path(__file__).parent.parent.parent / ".env"
+if env_path.exists():
+    load_dotenv(dotenv_path=env_path)
+
+# Import models so Alembic can see the metadata
+from sqlmodel import SQLModel  # noqa: E402
+
+from models import Nonce, Room, User  # noqa: F401, E402
+
+config = context.config
+
+if config.config_file_name is not None:
+    fileConfig(config.config_file_name)
+
+target_metadata = SQLModel.metadata
+
+
+def get_url() -> str:
+    url = os.getenv("DATABASE_URL")
+    if not url:
+        raise RuntimeError("DATABASE_URL environment variable is not set")
+    # Automatic local development redirection
+    if "@db:" in url and not Path("/.dockerenv").exists():
+        url = url.replace("@db:", "@localhost:")
+    return url
+
+
+def run_migrations_offline() -> None:
+    url = get_url()
+    context.configure(
+        url=url,
+        target_metadata=target_metadata,
+        literal_binds=True,
+        dialect_opts={"paramstyle": "named"},
+    )
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online() -> None:
+    configuration = config.get_section(config.config_ini_section, {})
+    configuration["sqlalchemy.url"] = get_url()
+    connectable = engine_from_config(
+        configuration,
+        prefix="sqlalchemy.",
+        poolclass=pool.NullPool,
+    )
+    with connectable.connect() as connection:
+        context.configure(connection=connection, target_metadata=target_metadata)
+        with context.begin_transaction():
+            context.run_migrations()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/backend/alembic/versions/001_initial.py
+++ b/backend/alembic/versions/001_initial.py
@@ -1,0 +1,82 @@
+"""initial tables
+
+Revision ID: 001
+Revises:
+Create Date: 2026-04-07
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "001"
+down_revision: str | None = None
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    existing_tables = inspector.get_table_names()
+
+    # These tables may already exist on production (created via create_all)
+    if "user" not in existing_tables:
+        op.create_table(
+            "user",
+            sa.Column("id", sa.Integer(), nullable=False),
+            sa.Column("identity_address", sa.String(), nullable=False),
+            sa.Column("username", sa.String(), nullable=False),
+            sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+            sa.Column("last_login", sa.DateTime(timezone=True), nullable=True),
+            sa.PrimaryKeyConstraint("id"),
+        )
+        op.create_index(
+            "ix_user_identity_address", "user", ["identity_address"], unique=True
+        )
+        op.create_index("ix_user_username", "user", ["username"], unique=True)
+
+    if "nonce" not in existing_tables:
+        op.create_table(
+            "nonce",
+            sa.Column("id", sa.Integer(), nullable=False),
+            sa.Column("identity_address", sa.String(), nullable=False),
+            sa.Column("value", sa.String(), nullable=False),
+            sa.Column("expires_at", sa.DateTime(timezone=True), nullable=False),
+            sa.Column("used", sa.Boolean(), nullable=False),
+            sa.Column("user_id", sa.Integer(), nullable=True),
+            sa.ForeignKeyConstraint(["user_id"], ["user.id"]),
+            sa.PrimaryKeyConstraint("id"),
+            sa.UniqueConstraint("value"),
+        )
+        op.create_index(
+            "ix_nonce_identity_address", "nonce", ["identity_address"], unique=False
+        )
+
+    # room is always new
+    if "room" not in existing_tables:
+        op.create_table(
+            "room",
+            sa.Column("id", sa.Integer(), nullable=False),
+            sa.Column("name", sa.String(), nullable=False),
+            sa.Column("game", sa.String(), nullable=False),
+            sa.Column("players_max", sa.Integer(), nullable=False),
+            sa.Column("players_active", sa.Integer(), nullable=False),
+            sa.Column("created_by", sa.String(), nullable=False),
+            sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+            sa.PrimaryKeyConstraint("id"),
+        )
+        op.create_index("ix_room_name", "room", ["name"], unique=True)
+        op.create_index("ix_room_created_by", "room", ["created_by"], unique=False)
+
+
+def downgrade() -> None:
+    op.drop_table("room")
+    op.drop_index("ix_nonce_identity_address", table_name="nonce")
+    op.drop_table("nonce")
+    op.drop_index("ix_user_identity_address", table_name="user")
+    op.drop_index("ix_user_username", table_name="user")
+    op.drop_table("user")

--- a/backend/entrypoint.sh
+++ b/backend/entrypoint.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+set -e
+alembic upgrade head
+exec uvicorn main:app --host 0.0.0.0 --port 8000

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,4 +1,5 @@
 import hashlib
+import json
 import os
 import uuid
 from contextlib import asynccontextmanager
@@ -11,14 +12,14 @@ from dotenv import load_dotenv
 from eth_account import Account
 from eth_account.messages import encode_defunct
 from eth_utils.address import to_checksum_address
-from fastapi import Depends, FastAPI, HTTPException
+from fastapi import Depends, FastAPI, HTTPException, WebSocket, WebSocketDisconnect
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.security import OAuth2PasswordBearer
 from pydantic import BaseModel
 from sqlmodel import Session, select
 
-from database import create_db_and_tables, get_session
-from models import Nonce, User
+from database import get_session
+from models import Nonce, Room, User
 
 # Load .env from project root if it exists
 env_path = Path(__file__).parent.parent / ".env"
@@ -46,9 +47,48 @@ class VerifyRequest(BaseModel):
     signature: str
 
 
+class CreateRoomRequest(BaseModel):
+    name: str
+    game: str
+    players_max: int
+
+
+# --- WebSocket connection manager ---
+class ConnectionManager:
+    def __init__(self):
+        self.active_connections: list[WebSocket] = []
+
+    async def connect(self, websocket: WebSocket):
+        await websocket.accept()
+        self.active_connections.append(websocket)
+
+    def disconnect(self, websocket: WebSocket):
+        self.active_connections.remove(websocket)
+
+    async def broadcast(self, data: str):
+        for connection in self.active_connections:
+            await connection.send_text(data)
+
+
+manager = ConnectionManager()
+
+
 # --- Helpers ---
 def hash_nonce(nonce_value: str) -> str:
     return hashlib.sha256(nonce_value.encode()).hexdigest()
+
+
+def get_rooms_payload(session: Session) -> str:
+    return json.dumps(
+        [
+            {
+                "name": r.name,
+                "players_active": r.players_active,
+                "players_max": r.players_max,
+            }
+            for r in session.exec(select(Room)).all()
+        ]
+    )
 
 
 SessionDep = Annotated[Session, Depends(get_session)]
@@ -72,7 +112,6 @@ async def get_current_user_address(
 
 @asynccontextmanager
 async def lifespan(_app: FastAPI):
-    create_db_and_tables()
     yield
 
 
@@ -232,3 +271,43 @@ def get_me(
     if not user:
         raise HTTPException(status_code=404, detail="User not found")
     return user
+
+
+@app.get("/rooms")
+def list_rooms(session: SessionDep):
+    return session.exec(select(Room)).all()
+
+
+@app.post("/rooms", status_code=201)
+async def create_room(
+    body: CreateRoomRequest,
+    session: SessionDep,
+    address: Annotated[str, Depends(get_current_user_address)],
+):
+    existing = session.exec(select(Room).where(Room.name == body.name)).first()
+    if existing:
+        raise HTTPException(status_code=409, detail="Room name already taken")
+
+    room = Room(
+        name=body.name,
+        game=body.game,
+        players_max=body.players_max,
+        created_by=address,
+    )
+    session.add(room)
+    session.commit()
+    session.refresh(room)
+
+    await manager.broadcast(get_rooms_payload(session))
+    return room
+
+
+@app.websocket("/ws/rooms")
+async def websocket_rooms(websocket: WebSocket, session: SessionDep):
+    await manager.connect(websocket)
+    try:
+        await websocket.send_text(get_rooms_payload(session))
+        while True:
+            await websocket.receive_text()
+    except WebSocketDisconnect:
+        manager.disconnect(websocket)

--- a/backend/models.py
+++ b/backend/models.py
@@ -4,6 +4,16 @@ from datetime import UTC, datetime
 from sqlmodel import Field, Relationship, SQLModel
 
 
+class Room(SQLModel, table=True):
+    id: int | None = Field(default=None, primary_key=True)
+    name: str = Field(index=True, unique=True)
+    game: str
+    players_max: int
+    players_active: int = Field(default=0)
+    created_by: str = Field(index=True)  # identity_address of creator
+    created_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+
+
 class User(SQLModel, table=True):
     id: int | None = Field(default=None, primary_key=True)
     identity_address: str = Field(index=True, unique=True)

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -5,6 +5,7 @@ description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.14"
 dependencies = [
+    "alembic>=1.18.4",
     "eth-account>=0.13.7",
     "fastapi[standard]==0.135.1",
     "psycopg[binary]>=3.3.3",

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -3,6 +3,20 @@ revision = 3
 requires-python = ">=3.14"
 
 [[package]]
+name = "alembic"
+version = "1.18.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mako" },
+    { name = "sqlalchemy" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/94/13/8b084e0f2efb0275a1d534838844926f798bd766566b1375174e2448cd31/alembic-1.18.4.tar.gz", hash = "sha256:cb6e1fd84b6174ab8dbb2329f86d631ba9559dd78df550b57804d607672cedbc", size = 2056725, upload-time = "2026-02-10T16:00:47.195Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/29/6533c317b74f707ea28f8d633734dbda2119bbadfc61b2f3640ba835d0f7/alembic-1.18.4-py3-none-any.whl", hash = "sha256:a5ed4adcf6d8a4cb575f3d759f071b03cd6e5c7618eb796cb52497be25bfe19a", size = 263893, upload-time = "2026-02-10T16:00:49.997Z" },
+]
+
+[[package]]
 name = "annotated-doc"
 version = "0.0.4"
 source = { registry = "https://pypi.org/simple" }
@@ -37,6 +51,7 @@ name = "backend"
 version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
+    { name = "alembic" },
     { name = "eth-account" },
     { name = "fastapi", extra = ["standard"] },
     { name = "psycopg", extra = ["binary"] },
@@ -56,6 +71,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "alembic", specifier = ">=1.18.4" },
     { name = "eth-account", specifier = ">=0.13.7" },
     { name = "fastapi", extras = ["standard"], specifier = "==0.135.1" },
     { name = "psycopg", extras = ["binary"], specifier = ">=3.3.3" },
@@ -567,6 +583,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
+]
+
+[[package]]
+name = "mako"
+version = "1.3.10"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9e/38/bd5b78a920a64d708fe6bc8e0a2c075e1389d53bef8413725c63ba041535/mako-1.3.10.tar.gz", hash = "sha256:99579a6f39583fa7e5630a28c3c1f440e4e97a414b80372649c0ce338da2ea28", size = 392474, upload-time = "2025-04-10T12:44:31.16Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/87/fb/99f81ac72ae23375f22b7afdb7642aba97c00a713c217124420147681a2f/mako-1.3.10-py3-none-any.whl", hash = "sha256:baef24a52fc4fc514a0887ac600f9f1cff3d82c61d4d700a1fa84d597b88db59", size = 78509, upload-time = "2025-04-10T12:50:53.297Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #43

## Summary
- `Room` model (`name`, `game`, `players_max`, `players_active`, `created_by`, `created_at`)
- `GET /rooms` — list all rooms
- `POST /rooms` — create a room (requires JWT), broadcasts update via WebSocket
- `WebSocket /ws/rooms` — pushes current room list to all connected clients

## Migrations (Alembic)
Replaced `create_all` as the schema management mechanism. Migration `001_initial` creates `user`/`nonce` tables only if they don't exist (safe for existing prod DB), and always creates the new `room` table. On every deploy, `entrypoint.sh` runs `alembic upgrade head` before starting uvicorn.

## Test plan
- [ ] CI passes (lint, tests, docker build)
- [ ] After deploy: `/rooms` page shows the list (empty)
- [ ] `POST /rooms` with JWT creates a room and it appears in the list without page refresh