### PR TITLE
Wait for DB before running migrations

### DIFF
--- a/backend/entrypoint.sh
+++ b/backend/entrypoint.sh
@@ -1,4 +1,19 @@
 #!/bin/sh
 set -e
+
+for i in $(seq 1 30); do
+  python - <<'PY' && break
+import socket, sys
+try:
+    socket.getaddrinfo("db", 5432)
+    s = socket.create_connection(("db", 5432), timeout=2)
+    s.close()
+except Exception:
+    sys.exit(1)
+PY
+  echo "DB not ready yet ($i/30)"
+  sleep 2
+done
+
 alembic upgrade head
 exec uvicorn main:app --host 0.0.0.0 --port 8000


### PR DESCRIPTION
Add a startup loop that attempts to resolve and connect to the database host `db:5432` up to 30 times (2s interval) before running `alembic upgrade head` and starting uvicorn. This prevents migration/startup failures when the database isn't ready at container start by retrying the connection check using an inline Python socket probe and printing progress messages.