### PR TITLE
docs: sync project docs with current codebase

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,7 +60,8 @@ We use a simplified version of Conventional Commits to keep our history readable
 
 ---
 ## 🛠 Quality Control
--   **Backend:** Use `uv run pytest` for testing.
+-   **Backend:** `uv run pytest` for the test suite. After changing any SQLModel schema, generate a migration with `uv run alembic revision --autogenerate -m "..."` and commit it alongside the model change.
+-   **Frontend:** `bun run check` (svelte-check + TypeScript), `bun run lint` (ESLint), `bun run format` (Prettier).
 -   **Linting & Formatting:** Handled by [`prek`](https://github.com/drmorr0/prek) — a pre-commit hook runner that executes `ruff check --fix` and `ruff format` automatically on staged files before each commit. To run all hooks manually across the entire codebase (including ESLint and Prettier for the frontend):
 ```bash
 prek run --all-files

--- a/README.md
+++ b/README.md
@@ -1,18 +1,28 @@
-# Playlink - Moduł Sumatywny
+# Playlink — Moduł Sumatywny
 
-Playlink is a full-stack application providing secure, non-custodial identity management. The system is built with a FastAPI backend, a SvelteKit frontend, and a PostgreSQL database, orchestrated via Docker Compose.
+Playlink is a full-stack **LFG (Looking For Group)** web application for finding players for niche, retro, and less popular multiplayer titles. Users create short-lived game sessions ("rooms") and browse open lobbies in real time. Authentication is non-custodial: identity is derived locally from a BIP39 mnemonic and verified against the backend with an ECDSA signature.
+
+The system is built with a FastAPI backend, a SvelteKit frontend, and a PostgreSQL database, orchestrated via Docker Compose.
 
 **Project Kanban:** [GitHub Project Board](https://github.com/orgs/ioad-modul-sumatywny-26/projects/2)
 
 ## Access
 
-Frontend and backend are available at:  
-[frontend](https://playlink.bartek.monster/)
-[backend documentation](https://playlink-backend.bartek.monster/docs)
+Frontend and backend are available at:
+
+- [Frontend](https://playlink.bartek.monster/)
+- [Backend documentation](https://playlink-backend.bartek.monster/docs)
 
 ## Deployment
 
-Changes merged into the `main` branch are automatically deployed. The deployment process typically takes between 30 seconds and 5 minutes to complete, depending on the scope and complexity of the changes..
+Changes merged into the `main` branch are automatically deployed. The deployment process typically takes between 30 seconds and 5 minutes to complete, depending on the scope and complexity of the changes.
+
+## Features
+
+- **Identity authentication** — BIP39 mnemonic + ECDSA signature challenge, JWT session.
+- **Rooms** — create, list, join, and leave game sessions through REST endpoints.
+- **Realtime room list** — WebSocket broadcast pushes the current room list to all connected clients on every change.
+- **Game catalog** — pre-seeded list of supported games (Quake III Arena, Diablo II, StarCraft, Half-Life, Unreal Tournament).
 
 ## Technical Architecture
 
@@ -22,6 +32,8 @@ Changes merged into the `main` branch are automatically deployed. The deployment
 | Backend        | FastAPI (Python)       | uv         |
 | Database       | PostgreSQL 18          | Docker     |
 | ORM            | SQLModel               | —          |
+| Migrations     | Alembic                | uv         |
+| Realtime       | WebSockets (FastAPI)   | —          |
 | Authentication | BIP39 Identity / ECDSA | ethers.js  |
 | Git Hooks      | prek                   | uv         |
 
@@ -34,11 +46,30 @@ The application utilizes a non-custodial challenge-response mechanism based on B
 3. **Cryptographic Proof:** The client signs the challenge using the derived private key.
 4. **Session Verification:** The backend verifies the signature against the nonce and issues a JSON Web Token (JWT).
 
-Detailed specifications are available in `backend/docs/auth-flow.md`.
+Detailed specifications are available in [`backend/docs/auth-flow.md`](backend/docs/auth-flow.md).
+
+## Local Development
+
+The fastest way to run the full stack locally:
+
+```bash
+cp .env.example .env
+cp frontend/.env.example frontend/.env
+docker compose up --build
+```
+
+Services:
+
+- Frontend — `http://localhost:3000`
+- Backend (OpenAPI docs at `/docs`) — `http://localhost:8000`
+- PostgreSQL — `localhost:5432`
+
+For running each service outside Docker, see [`backend/README.md`](backend/README.md) and [`frontend/README.md`](frontend/README.md).
 
 ## Project Organization
 
-- `backend/`: API services, database models, and authentication logic.
-- `frontend/`: SvelteKit application and identity management UI.
-- `prezentacje/`: Project documentation and presentation materials.
-- `docker-compose.yml`: Multi-container orchestration configuration.
+- `backend/` — FastAPI service, SQLModel schemas, Alembic migrations, authentication and rooms logic.
+- `frontend/` — SvelteKit application and identity management UI.
+- `prezentacje/` — Project documentation and presentation materials.
+- `docker-compose.yml` — Multi-container orchestration configuration.
+- `CONTRIBUTING.md` — Workflow, branching, and quality standards.

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,4 +1,4 @@
-, # Playlink Backend (FastAPI)
+# Playlink Backend (FastAPI)
 
 FastAPI application handling identity authentication, room management, and realtime room-list broadcasting over WebSockets.
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,58 +1,128 @@
-# Playlink Backend (FastAPI)
+, # Playlink Backend (FastAPI)
 
-FastAPI application handling identity authentication and room/session management.
+FastAPI application handling identity authentication, room management, and realtime room-list broadcasting over WebSockets.
 
 ## Tech Stack
+
 - **Framework:** FastAPI
 - **ORM:** SQLModel (SQLAlchemy + Pydantic)
-- **Database:** PostgreSQL (Production/Docker) / SQLite (Testing)
-- **Auth:** Identity Address (BIP39-compatible signatures) + JWT
+- **Database:** PostgreSQL (production / Docker) / SQLite (testing)
+- **Migrations:** Alembic
+- **Auth:** BIP39 identity address + ECDSA signature verification, JWT sessions
 - **Package Manager:** `uv`
 
-## Core Authentication Flow
-The backend implements a challenge-response authentication mechanism:
-1. **Request Challenge:** Client sends their `identity_address` to `/auth/request-nonce`.
-2. **Local Signing:** Client signs a message containing the nonce using their private key.
-3. **Verification:** Client sends the signature back to `/auth/verify`.
-4. **JWT Issuance:** If valid, the backend issues a JWT for secure sessions.
-
 ## Project Structure
-- `main.py`: API endpoints and application lifecycle.
-- `models.py`: SQLModel database schemas.
-- `database.py`: Database engine and session management.
-- `tests/`: Pytest suite.
+
+- `main.py` — API endpoints, WebSocket handler, application lifecycle.
+- `models.py` — SQLModel schemas (`User`, `Nonce`, `Room`, `RoomMember`, `Game`).
+- `database.py` — Engine and session management. Auto-rewrites `@db:` to `@localhost:` when not running inside a container.
+- `alembic/` — Migration environment and version scripts.
+- `entrypoint.sh` — Container entrypoint: waits for the DB, runs `alembic upgrade head`, then starts uvicorn.
+- `docs/auth-flow.md` — Detailed authentication flow specification.
+- `tests/` — Pytest suite.
+
+## API Endpoints
+
+| Method | Path                       | Auth | Description                                                                                                                                       |
+| ------ | -------------------------- | ---- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| GET    | `/`                        | —    | Service health check.                                                                                                                             |
+| POST   | `/auth/request-nonce`      | —    | Request a one-time nonce for an identity address.                                                                                                 |
+| POST   | `/auth/verify`             | —    | Verify a signed nonce and receive a JWT.                                                                                                          |
+| GET    | `/users/me`                | JWT  | Return the authenticated user.                                                                                                                    |
+| GET    | `/rooms`                   | —    | List all rooms.                                                                                                                                   |
+| POST   | `/rooms`                   | JWT  | Create a room (max 3 active rooms per user). Auto-joins the creator.                                                                              |
+| POST   | `/rooms/{room_name}/join`  | JWT  | Join a room (rejected if full or already a member).                                                                                               |
+| POST   | `/rooms/{room_name}/leave` | JWT  | Leave a room.                                                                                                                                     |
+| GET    | `/games`                   | —    | List supported game names, ordered by `sort_order`.                                                                                               |
+| WS     | `/ws/rooms`                | —    | On connect, sends the current room list as JSON. Broadcasts an updated list to all connected clients whenever a room is created, joined, or left. |
+
+OpenAPI docs are served at `/docs`.
+
+## Realtime
+
+A `ConnectionManager` in `main.py` keeps the set of active WebSocket clients. After every successful `POST /rooms`, `/rooms/{name}/join`, or `/rooms/{name}/leave`, the server broadcasts the full room list (computed by `get_rooms_payload`) to every connected client. Expired rooms (`expires_at <= now`) are pruned during this step.
+
+## Authentication Flow (Summary)
+
+1. Client `POST`s its `identity_address` to `/auth/request-nonce`.
+2. Client signs the message `Sign in to Playlink\nNonce: <uuid>` locally.
+3. Client `POST`s `{ address, nonce, signature }` to `/auth/verify`.
+4. Backend recovers the address from the signature, marks the nonce as used, and issues a JWT.
+
+Authenticated endpoints expect `Authorization: Bearer <token>` (OAuth2 password bearer scheme). Full specification in [`docs/auth-flow.md`](docs/auth-flow.md).
 
 ## Development Setup
 
 ### 1. Prerequisites
+
 - Install `uv`: `curl -LsSf https://astral.sh/uv/install.sh | sh`
 - Python 3.14+
+- A running PostgreSQL instance (or use Docker Compose from the project root).
 
 ### 2. Environment Configuration
-Create a `.env` file in the project root:
-```env
-DATABASE_URL=postgresql+psycopg://postgres:postgres@localhost:5432/playlink
-JWT_SECRET=your-secure-secret-here
-```
+
+Copy `.env.example` from the project root to `.env`. The backend reads it via `python-dotenv`.
+
+| Variable                   | Purpose                                                                        | Default |
+| -------------------------- | ------------------------------------------------------------------------------ | ------- |
+| `DATABASE_URL`             | SQLAlchemy URL (e.g. `postgresql+psycopg://user:pass@host:5432/db`). Required. | —       |
+| `JWT_SECRET`               | Secret used to sign JWTs. Required.                                            | —       |
+| `JWT_ALGORITHM`            | JWT signing algorithm.                                                         | `HS256` |
+| `NONCE_EXPIRATION_MINUTES` | TTL for issued auth nonces.                                                    | `5`     |
+| `JWT_EXPIRATION_MINUTES`   | TTL for issued JWT sessions.                                                   | `60`    |
+
+CORS is hard-coded in `main.py` for `playlink.bartek.monster`, `localhost:3000`, `localhost:5173`, and their `127.0.0.1` equivalents.
 
 ### 3. Install Dependencies
+
 ```bash
 uv sync
 ```
 
-### 4. Running the API
+### 4. Apply Migrations
+
+From the `backend/` directory:
+
 ```bash
-uv run uvicorn backend.main:app --reload
+uv run alembic upgrade head
 ```
 
+### 5. Run the API
+
+From the `backend/` directory:
+
+```bash
+uv run uvicorn main:app --reload
+```
+
+The API will be available at `http://localhost:8000` with interactive docs at `/docs`.
+
+## Database Migrations
+
+Alembic is configured against the SQLModel metadata. To create a new migration after changing models:
+
+```bash
+cd backend
+uv run alembic revision --autogenerate -m "describe change"
+uv run alembic upgrade head
+```
+
+In Docker, `entrypoint.sh` runs `alembic upgrade head` automatically before launching uvicorn.
+
 ## Running Tests
+
 Tests use an in-memory SQLite database and do not require PostgreSQL to be running.
+
 ```bash
 uv run pytest
 ```
 
 ## Docker
-The backend is designed to run via Docker Compose in the project root:
+
+The backend is designed to run via Docker Compose from the project root:
+
 ```bash
 docker compose up --build backend
 ```
+
+The container waits for the `db` service to accept connections, runs migrations, and then starts uvicorn on port `8000`.

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -31,10 +31,10 @@ bun install
 
 Copy `frontend/.env.example` to `frontend/.env`. The public variables exposed via `$env/dynamic/public`:
 
-| Variable             | Purpose                                            | Example                  |
-| -------------------- | -------------------------------------------------- | ------------------------ |
-| `PUBLIC_BACKEND_URL` | Base URL of the FastAPI backend (HTTP).            | `http://localhost:8000`  |
-| `PUBLIC_WS_URL`      | Base URL for the rooms WebSocket (`ws://`/`wss://`). | `ws://localhost:8000`  |
+| Variable             | Purpose                                              | Example                 |
+| -------------------- | ---------------------------------------------------- | ----------------------- |
+| `PUBLIC_BACKEND_URL` | Base URL of the FastAPI backend (HTTP).              | `http://localhost:8000` |
+| `PUBLIC_WS_URL`      | Base URL for the rooms WebSocket (`ws://`/`wss://`). | `ws://localhost:8000`   |
 
 ### 3. Running the Dev Server
 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,16 +1,19 @@
 # Frontend — SvelteKit
 
-SvelteKit-based frontend for the Playlink project.
+SvelteKit-based frontend for the Playlink project. Implements the BIP39 sign-in flow and the rooms browser, talking to the FastAPI backend over REST and WebSockets.
 
 ## Requirements
 
 - **Bun** (latest)
 
-## Technologies Used
+## Tech Stack
 
-- **Svelte** `^5.51.0` (latest)
-- **SvelteKit** `^2.50.2`
-- **Bun** (Runtime, Package Manager, Bundler)
+- **Svelte** `^5.51.0` (runes mode: `$state`, `$derived`, `$effect`, `$props`)
+- **SvelteKit** `^2.50.2` with `@sveltejs/adapter-node`
+- **TypeScript** (strict)
+- **Bun** — runtime, package manager, bundler
+- **ethers** + **viem** — local mnemonic derivation and ECDSA signing
+- **jwt-decode** — server-side decoding of the session cookie
 
 ## Getting Started
 
@@ -19,74 +22,96 @@ SvelteKit-based frontend for the Playlink project.
 
 ### 1. Installation
 
-Install dependencies:
-
 ```bash
 cd frontend
 bun install
 ```
 
-### 2. Running the Dev Server
+### 2. Environment Variables
 
-Start the development server:
+Copy `frontend/.env.example` to `frontend/.env`. The public variables exposed via `$env/dynamic/public`:
+
+| Variable             | Purpose                                            | Example                  |
+| -------------------- | -------------------------------------------------- | ------------------------ |
+| `PUBLIC_BACKEND_URL` | Base URL of the FastAPI backend (HTTP).            | `http://localhost:8000`  |
+| `PUBLIC_WS_URL`      | Base URL for the rooms WebSocket (`ws://`/`wss://`). | `ws://localhost:8000`  |
+
+### 3. Running the Dev Server
 
 ```bash
 bun dev
 
 # or open in browser automatically
-bun dev -- --open
+bun dev --open
 ```
 
-The app will be available at `http://localhost:5173/`
+The app will be available at `http://localhost:5173/`.
 
-Before starting the frontend locally, create `frontend/.env` from `frontend/.env.example`.
-The public variables used by the app are:
-
-```bash
-PUBLIC_BACKEND_URL=http://localhost:8000
-PUBLIC_WS_URL=ws://localhost:8000
-```
-
-### 3. Building for Production
+### 4. Building for Production
 
 ```bash
 bun run build
 ```
 
-Output is placed under `.svelte-kit/output/`. For deployment, install an
-[adapter](https://svelte.dev/docs/kit/adapters) suited to your target platform.
+The project uses `@sveltejs/adapter-node`; the build output is a Node server suitable for the bundled `Dockerfile`.
 
-### 4. Previewing the Production Build
+### 5. Previewing the Production Build
 
 ```bash
 bun run preview
 ```
+
+## Routes
+
+- `/` — Landing page.
+- `/auth` — Mnemonic input, signs the auth challenge locally, and exchanges the resulting JWT for an httpOnly `session` cookie via the SvelteKit form action.
+- `/rooms` — Lists active rooms, subscribes to the `/ws/rooms` WebSocket for live updates, and exposes create/join/leave actions for authenticated users.
+- `/test` — Internal scratchpad route.
+
+## Authentication (BFF Pattern)
+
+The JWT issued by the backend never reaches client-side JavaScript. The flow:
+
+1. The client derives the identity from the mnemonic and signs the backend nonce locally (`ethers` / `viem`).
+2. The signed proof is sent to the backend, which returns a JWT.
+3. The JWT is posted to the SvelteKit `login` action in `routes/auth/+page.server.ts`, which stores it in an `httpOnly`, `sameSite=strict` cookie named `session`.
+4. Server-side loaders read the cookie, decode the JWT (`jwt-decode`), and expose only the address/username to the page.
 
 ## Project Structure
 
 ```
 frontend/
 ├── src/
-│   ├── lib/             # Shared Svelte components and utilities
-│   │   └── index.js     # Public exports
-│   ├── routes/          # SvelteKit file-based routing
-│   │   ├── +layout.svelte  # Root layout
-│   │   └── +page.svelte    # Home page
-│   └── app.html         # HTML shell
-├── static/              # Static assets served as-is
-├── jsconfig.json
+│   ├── lib/
+│   │   ├── assets/                # Static assets imported by components
+│   │   ├── components/
+│   │   │   └── MnemonicInput.svelte
+│   │   ├── auth.ts                # Client-side mnemonic derivation & signing helpers
+│   │   ├── roomsStore.ts          # Svelte store backed by the rooms WebSocket
+│   │   ├── global.css             # Global styles
+│   │   └── index.ts               # Public re-exports
+│   ├── routes/
+│   │   ├── +layout.svelte
+│   │   ├── +page.svelte           # Landing page
+│   │   ├── auth/                  # Sign-in flow (+page.svelte, +page.server.ts)
+│   │   ├── rooms/                 # Rooms browser (+page.svelte, +page.server.ts)
+│   │   └── test/
+│   └── app.html
+├── static/
+├── tsconfig.json
 ├── package.json
-├── svelte.config.js     # SvelteKit + Svelte configuration
+├── svelte.config.js
 └── vite.config.js
+```
+
+## Quality Control
+
+```bash
+bun run check    # svelte-check + TypeScript
+bun run lint     # ESLint
+bun run format   # Prettier
 ```
 
 ## Recommended IDE Setup
 
 [VS Code](https://code.visualstudio.com/) + [Svelte extension](https://marketplace.visualstudio.com/items?itemName=svelte.svelte-vscode).
-
-## Notes
-
-- This project uses **Svelte 5 runes** (`$state`, `$derived`, `$props`, etc.)
-  and **SvelteKit** for file-based routing, SSR, and adapter-based deployment.
-- To deploy, replace `@sveltejs/adapter-auto` with a platform-specific adapter
-  (e.g. `adapter-node`, `adapter-vercel`, `adapter-netlify`).


### PR DESCRIPTION
## Summary
Refresh of all `.md` documentation so it reflects the current state of the codebase (rooms backend + WebSocket, TS frontend, Alembic migrations, BFF auth pattern).

## Changes
- **`README.md`** — reframed as an LFG platform; added Features, Local Development quickstart, and Migrations/Realtime rows in the architecture table.
- **`backend/README.md`** — full API endpoint table (REST + WS), Realtime section, env var table with defaults, Database Migrations section, corrected `uvicorn main:app` run command, expanded Project Structure with `alembic/`, `entrypoint.sh`, `docs/`.
- **`frontend/README.md`** — corrected JS→TS structure, dropped stale `adapter-auto` note (project uses `adapter-node`), added Routes, BFF Pattern, env var table, and `bun run check/lint/format` commands.
- **`CONTRIBUTING.md`** — added frontend QC commands and a note to ship an Alembic migration with any model change.
- `backend/docs/auth-flow.md` left untouched; already matches the code.

Closes #49