### PR TITLE
feat: per-room realtime chat

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -110,6 +110,7 @@ jobs:
                       JWT_ALGORITHM=${{ vars.JWT_ALGORITHM }}
                       NONCE_EXPIRATION_MINUTES=${{ vars.NONCE_EXPIRATION_MINUTES }}
                       JWT_EXPIRATION_MINUTES=${{ vars.JWT_EXPIRATION_MINUTES }}
+                      ORIGIN=https://playlink.bartek.monster
                       EOF
 
                       cat > frontend/.env << EOF

--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -15,7 +15,7 @@ if env_path.exists():
 # Import models so Alembic can see the metadata
 from sqlmodel import SQLModel  # noqa: E402
 
-from models import Game, Nonce, Room, User  # noqa: F401, E402
+from models import Game, Message, Nonce, Room, User  # noqa: F401, E402
 
 config = context.config
 

--- a/backend/alembic/versions/a1b2c3d4e5f6_add_message.py
+++ b/backend/alembic/versions/a1b2c3d4e5f6_add_message.py
@@ -1,0 +1,56 @@
+"""add message
+
+Revision ID: a1b2c3d4e5f6
+Revises: f273b29c941a
+Create Date: 2026-05-06 12:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+import sqlmodel
+
+from alembic import op
+
+revision: str = "a1b2c3d4e5f6"
+down_revision: str | None = "f273b29c941a"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "message",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("room_id", sa.Integer(), nullable=False),
+        sa.Column(
+            "sender_address", sqlmodel.sql.sqltypes.AutoString(), nullable=False
+        ),
+        sa.Column("content", sqlmodel.sql.sqltypes.AutoString(), nullable=False),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["room_id"],
+            ["room.id"],
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        op.f("ix_message_room_id"), "message", ["room_id"], unique=False
+    )
+    op.create_index(
+        op.f("ix_message_sender_address"),
+        "message",
+        ["sender_address"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_message_created_at"), "message", ["created_at"], unique=False
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(op.f("ix_message_created_at"), table_name="message")
+    op.drop_index(op.f("ix_message_sender_address"), table_name="message")
+    op.drop_index(op.f("ix_message_room_id"), table_name="message")
+    op.drop_table("message")

--- a/backend/alembic/versions/a1b2c3d4e5f6_add_message.py
+++ b/backend/alembic/versions/a1b2c3d4e5f6_add_message.py
@@ -24,9 +24,7 @@ def upgrade() -> None:
         "message",
         sa.Column("id", sa.Integer(), nullable=False),
         sa.Column("room_id", sa.Integer(), nullable=False),
-        sa.Column(
-            "sender_address", sqlmodel.sql.sqltypes.AutoString(), nullable=False
-        ),
+        sa.Column("sender_address", sqlmodel.sql.sqltypes.AutoString(), nullable=False),
         sa.Column("content", sqlmodel.sql.sqltypes.AutoString(), nullable=False),
         sa.Column("created_at", sa.DateTime(), nullable=False),
         sa.ForeignKeyConstraint(
@@ -35,9 +33,7 @@ def upgrade() -> None:
         ),
         sa.PrimaryKeyConstraint("id"),
     )
-    op.create_index(
-        op.f("ix_message_room_id"), "message", ["room_id"], unique=False
-    )
+    op.create_index(op.f("ix_message_room_id"), "message", ["room_id"], unique=False)
     op.create_index(
         op.f("ix_message_sender_address"),
         "message",

--- a/backend/main.py
+++ b/backend/main.py
@@ -157,7 +157,7 @@ async def get_current_user_address(
         return _decode_jwt(token)
     except jwt.ExpiredSignatureError:
         raise HTTPException(status_code=401, detail="Token expired") from None
-    except (jwt.InvalidTokenError, KeyError):
+    except jwt.InvalidTokenError, KeyError:
         raise HTTPException(status_code=401, detail="Invalid token") from None
 
 
@@ -579,7 +579,7 @@ async def websocket_chat(
             try:
                 data = json.loads(raw)
                 content = str(data.get("content", "")).strip()
-            except (ValueError, TypeError):
+            except ValueError, TypeError:
                 continue
             if not content or len(content) > 1000:
                 continue

--- a/backend/main.py
+++ b/backend/main.py
@@ -19,7 +19,7 @@ from pydantic import BaseModel
 from sqlmodel import Session, select
 
 from database import get_session
-from models import Game, Nonce, Room, User
+from models import Game, Message, Nonce, Room, User
 
 # Load .env from project root if it exists
 env_path = Path(__file__).parent.parent / ".env"
@@ -73,6 +73,28 @@ class ConnectionManager:
 manager = ConnectionManager()
 
 
+class RoomChatManager:
+    def __init__(self):
+        self.rooms: dict[str, list[WebSocket]] = {}
+
+    async def connect(self, room: str, websocket: WebSocket):
+        await websocket.accept()
+        self.rooms.setdefault(room, []).append(websocket)
+
+    def disconnect(self, room: str, websocket: WebSocket):
+        if room in self.rooms and websocket in self.rooms[room]:
+            self.rooms[room].remove(websocket)
+            if not self.rooms[room]:
+                del self.rooms[room]
+
+    async def broadcast(self, room: str, payload: str):
+        for connection in list(self.rooms.get(room, [])):
+            await connection.send_text(payload)
+
+
+chat_manager = RoomChatManager()
+
+
 # --- Helpers ---
 def hash_nonce(nonce_value: str) -> str:
     return hashlib.sha256(nonce_value.encode()).hexdigest()
@@ -84,6 +106,11 @@ def get_rooms_payload(session: Session) -> str:
     # Optional cleanup of expired rooms before returning the payload
     expired_rooms = session.exec(select(Room).where(Room.expires_at <= now)).all()
     for er in expired_rooms:
+        old_messages = session.exec(
+            select(Message).where(Message.room_id == er.id)
+        ).all()
+        for m in old_messages:
+            session.delete(m)
         session.delete(er)
     if expired_rooms:
         session.commit()
@@ -112,22 +139,60 @@ SessionDep = Annotated[Session, Depends(get_session)]
 oauth2_scheme = OAuth2PasswordBearer(tokenUrl="auth/verify", auto_error=False)
 
 
+def _decode_jwt(token: str) -> str:
+    """Decode a JWT and return its `sub` claim. Raises on any failure."""
+    payload = jwt.decode(token, JWT_SECRET, algorithms=[JWT_ALGORITHM])
+    address = payload.get("sub")
+    if not isinstance(address, str):
+        raise jwt.InvalidTokenError("Missing sub claim")
+    return address
+
+
 async def get_current_user_address(
     token: Annotated[str | None, Depends(oauth2_scheme)],
 ) -> str:
     if not token:
         raise HTTPException(status_code=401, detail="Not authenticated")
     try:
-        payload = jwt.decode(token, JWT_SECRET, algorithms=[JWT_ALGORITHM])
-        return payload["sub"]
+        return _decode_jwt(token)
     except jwt.ExpiredSignatureError:
         raise HTTPException(status_code=401, detail="Token expired") from None
-    except jwt.InvalidTokenError, KeyError:
+    except (jwt.InvalidTokenError, KeyError):
         raise HTTPException(status_code=401, detail="Invalid token") from None
+
+
+DEFAULT_GAMES: list[str] = [
+    "Quake III Arena",
+    "Diablo II",
+    "StarCraft",
+    "Half-Life",
+    "Unreal Tournament",
+]
+
+
+def seed_default_games() -> None:
+    """Idempotent: insert any DEFAULT_GAMES rows that don't exist yet."""
+    from database import engine
+
+    with Session(engine) as session:
+        existing = {g.name for g in session.exec(select(Game)).all()}
+        next_order = 1 + max(
+            (g.sort_order for g in session.exec(select(Game)).all()), default=0
+        )
+        added = False
+        for name in DEFAULT_GAMES:
+            if name in existing:
+                continue
+            session.add(Game(name=name, sort_order=next_order))
+            next_order += 1
+            added = True
+        if added:
+            session.commit()
 
 
 @asynccontextmanager
 async def lifespan(_app: FastAPI):
+    seed_default_games()
     yield
 
 
@@ -294,6 +359,25 @@ def list_rooms(session: SessionDep):
     return session.exec(select(Room)).all()
 
 
+@app.get("/rooms/{room_name}")
+def get_room(room_name: str, session: SessionDep):
+    room = session.exec(select(Room).where(Room.name == room_name)).first()
+    if not room:
+        raise HTTPException(status_code=404, detail="Room not found")
+    return {
+        "name": room.name,
+        "game": room.game,
+        "players_max": room.players_max,
+        "players_active": len(room.members),
+        "member_addresses": [m.identity_address for m in room.members],
+        "expires_at": (
+            room.expires_at.isoformat() + "Z"
+            if room.expires_at.tzinfo is None
+            else room.expires_at.isoformat()
+        ),
+    }
+
+
 @app.get("/games")
 def list_games(session: SessionDep):
     games = session.exec(select(Game).order_by(Game.sort_order)).all()
@@ -311,6 +395,11 @@ async def create_room(
     # Clean up expired rooms for accurate counts
     expired_rooms = session.exec(select(Room).where(Room.expires_at <= now)).all()
     for er in expired_rooms:
+        old_messages = session.exec(
+            select(Message).where(Message.room_id == er.id)
+        ).all()
+        for m in old_messages:
+            session.delete(m)
         session.delete(er)
     session.commit()
 
@@ -412,3 +501,103 @@ async def websocket_rooms(websocket: WebSocket, session: SessionDep):
             await websocket.receive_text()
     except WebSocketDisconnect:
         manager.disconnect(websocket)
+
+
+def _msg_dict(msg: Message, sender_username: str) -> dict:
+    created = msg.created_at
+    iso = created.isoformat() + "Z" if created.tzinfo is None else created.isoformat()
+    return {
+        "id": msg.id,
+        "sender_address": msg.sender_address,
+        "sender_username": sender_username,
+        "content": msg.content,
+        "created_at": iso,
+    }
+
+
+@app.websocket("/ws/rooms/{room_name}/chat")
+async def websocket_chat(
+    websocket: WebSocket,
+    room_name: str,
+    token: str,
+    session: SessionDep,
+):
+    # 1. Authenticate via JWT in query param (browsers can't set WS headers).
+    try:
+        address = _decode_jwt(token)
+    except Exception:
+        await websocket.close(code=4401)
+        return
+
+    # 2. Room must exist.
+    room = session.exec(select(Room).where(Room.name == room_name)).first()
+    if not room:
+        await websocket.close(code=4404)
+        return
+
+    # 3. Caller must be a member.
+    user = session.exec(select(User).where(User.identity_address == address)).first()
+    if not user or user not in room.members:
+        await websocket.close(code=4403)
+        return
+
+    await chat_manager.connect(room_name, websocket)
+    try:
+        # Send last 50 messages in chronological order.
+        recent = session.exec(
+            select(Message)
+            .where(Message.room_id == room.id)
+            .order_by(Message.created_at.desc())
+            .limit(50)
+        ).all()
+        username_cache: dict[str, str] = {}
+
+        def _username_for(addr: str) -> str:
+            cached = username_cache.get(addr)
+            if cached is not None:
+                return cached
+            sender = session.exec(
+                select(User).where(User.identity_address == addr)
+            ).first()
+            name = sender.username if sender else addr
+            username_cache[addr] = name
+            return name
+
+        history_payload = json.dumps(
+            {
+                "type": "history",
+                "messages": [
+                    _msg_dict(m, _username_for(m.sender_address))
+                    for m in reversed(recent)
+                ],
+            }
+        )
+        await websocket.send_text(history_payload)
+
+        while True:
+            raw = await websocket.receive_text()
+            try:
+                data = json.loads(raw)
+                content = str(data.get("content", "")).strip()
+            except (ValueError, TypeError):
+                continue
+            if not content or len(content) > 1000:
+                continue
+
+            msg = Message(
+                room_id=room.id,
+                sender_address=address,
+                content=content,
+            )
+            session.add(msg)
+            session.commit()
+            session.refresh(msg)
+
+            await chat_manager.broadcast(
+                room_name,
+                json.dumps(
+                    {"type": "message", "message": _msg_dict(msg, user.username)}
+                ),
+            )
+    except WebSocketDisconnect:
+        chat_manager.disconnect(room_name, websocket)

--- a/backend/models.py
+++ b/backend/models.py
@@ -29,9 +29,7 @@ class Message(SQLModel, table=True):
     room_id: int = Field(foreign_key="room.id", index=True)
     sender_address: str = Field(index=True)
     content: str
-    created_at: datetime = Field(
-        default_factory=lambda: datetime.now(UTC), index=True
-    )
+    created_at: datetime = Field(default_factory=lambda: datetime.now(UTC), index=True)
 
 
 class Game(SQLModel, table=True):

--- a/backend/models.py
+++ b/backend/models.py
@@ -18,10 +18,20 @@ class Room(SQLModel, table=True):
     created_by: str = Field(index=True)  # identity_address of creator
     created_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
     expires_at: datetime = Field(
-        default_factory=lambda: datetime.now(UTC) + timedelta(minutes=1)
+        default_factory=lambda: datetime.now(UTC) + timedelta(minutes=60)
     )
 
     members: list[User] = Relationship(back_populates="rooms", link_model=RoomMember)
+
+
+class Message(SQLModel, table=True):
+    id: int | None = Field(default=None, primary_key=True)
+    room_id: int = Field(foreign_key="room.id", index=True)
+    sender_address: str = Field(index=True)
+    content: str
+    created_at: datetime = Field(
+        default_factory=lambda: datetime.now(UTC), index=True
+    )
 
 
 class Game(SQLModel, table=True):

--- a/backend/tests/test_chat.py
+++ b/backend/tests/test_chat.py
@@ -1,0 +1,147 @@
+import os
+from datetime import UTC, datetime, timedelta
+
+import jwt
+import pytest
+from fastapi.testclient import TestClient
+from sqlmodel import Session, select
+from starlette.websockets import WebSocketDisconnect
+
+from models import Message, Room, User
+
+
+def _mint_token(address: str) -> str:
+    secret = os.environ["JWT_SECRET"]
+    payload = {
+        "sub": address,
+        "username": "tester",
+        "iat": datetime.now(UTC),
+        "exp": datetime.now(UTC) + timedelta(minutes=5),
+        "iss": "playlink-auth",
+    }
+    return jwt.encode(payload, secret, algorithm="HS256")
+
+
+def _all(session: Session, statement):
+    return session.exec(statement).all()
+
+
+def _seed_room_and_users(
+    session: Session, room_name: str, members: list[str]
+) -> Room:
+    user_objs = []
+    for addr in members:
+        u = User(identity_address=addr)
+        session.add(u)
+        user_objs.append(u)
+    session.commit()
+    for u in user_objs:
+        session.refresh(u)
+
+    room = Room(
+        name=room_name,
+        game="Quake III Arena",
+        players_max=4,
+        created_by=members[0],
+    )
+    room.members.extend(user_objs)
+    session.add(room)
+    session.commit()
+    session.refresh(room)
+    return room
+
+
+def test_chat_rejects_bad_token(client: TestClient, session: Session):
+    _seed_room_and_users(session, "r1", ["0xabc"])
+    with pytest.raises(WebSocketDisconnect) as exc:
+        with client.websocket_connect("/ws/rooms/r1/chat?token=garbage"):
+            pass
+    assert exc.value.code == 4401
+
+
+def test_chat_rejects_non_member(client: TestClient, session: Session):
+    _seed_room_and_users(session, "r2", ["0xMember"])
+    outsider = "0xOutsider"
+    session.add(User(identity_address=outsider))
+    session.commit()
+    token = _mint_token(outsider)
+    with pytest.raises(WebSocketDisconnect) as exc:
+        with client.websocket_connect(f"/ws/rooms/r2/chat?token={token}"):
+            pass
+    assert exc.value.code == 4403
+
+
+def test_chat_rejects_missing_room(client: TestClient, session: Session):
+    addr = "0xLone"
+    session.add(User(identity_address=addr))
+    session.commit()
+    token = _mint_token(addr)
+    with pytest.raises(WebSocketDisconnect) as exc:
+        with client.websocket_connect(f"/ws/rooms/nope/chat?token={token}"):
+            pass
+    assert exc.value.code == 4404
+
+
+def test_chat_broadcast_between_members(client: TestClient, session: Session):
+    a, b = "0xAlice", "0xBob"
+    _seed_room_and_users(session, "lobby", [a, b])
+    ta, tb = _mint_token(a), _mint_token(b)
+
+    with (
+        client.websocket_connect(f"/ws/rooms/lobby/chat?token={ta}") as ws_a,
+        client.websocket_connect(f"/ws/rooms/lobby/chat?token={tb}") as ws_b,
+    ):
+        history_a = ws_a.receive_json()
+        history_b = ws_b.receive_json()
+        assert history_a == {"type": "history", "messages": []}
+        assert history_b == {"type": "history", "messages": []}
+
+        ws_a.send_json({"content": "hello world"})
+
+        msg_a = ws_a.receive_json()
+        msg_b = ws_b.receive_json()
+        assert msg_a["type"] == "message"
+        assert msg_b["type"] == "message"
+        assert msg_a["message"]["content"] == "hello world"
+        assert msg_a["message"]["sender_address"] == a
+        assert msg_b["message"]["content"] == "hello world"
+
+    rows = _all(session, select(Message))
+    assert len(rows) == 1
+    assert rows[0].content == "hello world"
+
+
+def test_chat_history_replay(client: TestClient, session: Session):
+    addr = "0xSolo"
+    _seed_room_and_users(session, "echoes", [addr])
+    token = _mint_token(addr)
+
+    with client.websocket_connect(f"/ws/rooms/echoes/chat?token={token}") as ws:
+        ws.receive_json()
+        ws.send_json({"content": "first"})
+        ws.receive_json()
+        ws.send_json({"content": "second"})
+        ws.receive_json()
+
+    with client.websocket_connect(f"/ws/rooms/echoes/chat?token={token}") as ws:
+        history = ws.receive_json()
+        assert history["type"] == "history"
+        contents = [m["content"] for m in history["messages"]]
+        assert contents == ["first", "second"]
+
+
+def test_chat_drops_oversize_and_empty(client: TestClient, session: Session):
+    addr = "0xWriter"
+    _seed_room_and_users(session, "limited", [addr])
+    token = _mint_token(addr)
+
+    with client.websocket_connect(f"/ws/rooms/limited/chat?token={token}") as ws:
+        ws.receive_json()
+        ws.send_json({"content": "   "})
+        ws.send_json({"content": "x" * 1001})
+        ws.send_json({"content": "kept"})
+        msg = ws.receive_json()
+        assert msg["message"]["content"] == "kept"
+
+    rows = _all(session, select(Message))
+    assert [r.content for r in rows] == ["kept"]

--- a/backend/tests/test_chat.py
+++ b/backend/tests/test_chat.py
@@ -26,9 +26,7 @@ def _all(session: Session, statement):
     return session.exec(statement).all()
 
 
-def _seed_room_and_users(
-    session: Session, room_name: str, members: list[str]
-) -> Room:
+def _seed_room_and_users(session: Session, room_name: str, members: list[str]) -> Room:
     user_objs = []
     for addr in members:
         u = User(identity_address=addr)
@@ -53,9 +51,11 @@ def _seed_room_and_users(
 
 def test_chat_rejects_bad_token(client: TestClient, session: Session):
     _seed_room_and_users(session, "r1", ["0xabc"])
-    with pytest.raises(WebSocketDisconnect) as exc:
-        with client.websocket_connect("/ws/rooms/r1/chat?token=garbage"):
-            pass
+    with (
+        pytest.raises(WebSocketDisconnect) as exc,
+        client.websocket_connect("/ws/rooms/r1/chat?token=garbage"),
+    ):
+        pass
     assert exc.value.code == 4401
 
 
@@ -65,9 +65,11 @@ def test_chat_rejects_non_member(client: TestClient, session: Session):
     session.add(User(identity_address=outsider))
     session.commit()
     token = _mint_token(outsider)
-    with pytest.raises(WebSocketDisconnect) as exc:
-        with client.websocket_connect(f"/ws/rooms/r2/chat?token={token}"):
-            pass
+    with (
+        pytest.raises(WebSocketDisconnect) as exc,
+        client.websocket_connect(f"/ws/rooms/r2/chat?token={token}"),
+    ):
+        pass
     assert exc.value.code == 4403
 
 
@@ -76,9 +78,11 @@ def test_chat_rejects_missing_room(client: TestClient, session: Session):
     session.add(User(identity_address=addr))
     session.commit()
     token = _mint_token(addr)
-    with pytest.raises(WebSocketDisconnect) as exc:
-        with client.websocket_connect(f"/ws/rooms/nope/chat?token={token}"):
-            pass
+    with (
+        pytest.raises(WebSocketDisconnect) as exc,
+        client.websocket_connect(f"/ws/rooms/nope/chat?token={token}"),
+    ):
+        pass
     assert exc.value.code == 4404
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,10 +3,11 @@ services:
     image: postgres:18-alpine
     env_file:
       - .env
-    ports:
-      - "5432:5432"
+    # No host-port mapping: DB is only reachable on the docker network.
+    # Docker's iptables rules bypass UFW, so any `ports:` entry here would
+    # expose Postgres to the public internet regardless of host firewall.
     volumes:
-      - postgres_data:/var/lib/postgresql/data
+      - postgres_data:/var/lib/postgresql
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U $${POSTGRES_USER} -d $${POSTGRES_DB}"]
       interval: 10s
@@ -49,6 +50,10 @@ services:
       - "3000:3000"
     env_file:
       - frontend/.env
+    environment:
+      # Used by SvelteKit server-side `load`/actions for in-cluster calls.
+      # Browser code keeps using PUBLIC_BACKEND_URL / PUBLIC_WS_URL.
+      BACKEND_INTERNAL_URL: http://backend:8000
     depends_on:
       backend:
         condition: service_healthy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,6 +54,9 @@ services:
       # Used by SvelteKit server-side `load`/actions for in-cluster calls.
       # Browser code keeps using PUBLIC_BACKEND_URL / PUBLIC_WS_URL.
       BACKEND_INTERNAL_URL: http://backend:8000
+      # adapter-node CSRF check: must match the URL the browser uses.
+      # Defaults to localhost for dev; deploy overrides via root .env.
+      ORIGIN: ${ORIGIN:-http://localhost:3000}
     depends_on:
       backend:
         condition: service_healthy

--- a/frontend/src/lib/chatStore.ts
+++ b/frontend/src/lib/chatStore.ts
@@ -1,0 +1,135 @@
+import { browser } from '$app/environment';
+import { env } from '$env/dynamic/public';
+import { writable, type Readable } from 'svelte/store';
+
+export interface ChatMessage {
+	id: number;
+	sender_address: string;
+	sender_username: string;
+	content: string;
+	created_at: string;
+}
+
+interface HistoryFrame {
+	type: 'history';
+	messages: ChatMessage[];
+}
+
+interface MessageFrame {
+	type: 'message';
+	message: ChatMessage;
+}
+
+type ChatFrame = HistoryFrame | MessageFrame;
+
+function isChatMessage(value: unknown): value is ChatMessage {
+	if (typeof value !== 'object' || value === null) return false;
+	const m = value as Record<string, unknown>;
+	return (
+		typeof m.id === 'number' &&
+		typeof m.sender_address === 'string' &&
+		typeof m.sender_username === 'string' &&
+		typeof m.content === 'string' &&
+		typeof m.created_at === 'string'
+	);
+}
+
+function parseFrame(raw: string): ChatFrame | null {
+	let data: unknown;
+	try {
+		data = JSON.parse(raw);
+	} catch {
+		return null;
+	}
+	if (typeof data !== 'object' || data === null) return null;
+	const f = data as Record<string, unknown>;
+	if (f.type === 'history' && Array.isArray(f.messages) && f.messages.every(isChatMessage)) {
+		return { type: 'history', messages: f.messages as ChatMessage[] };
+	}
+	if (f.type === 'message' && isChatMessage(f.message)) {
+		return { type: 'message', message: f.message };
+	}
+	return null;
+}
+
+export interface ChatStore extends Readable<ChatMessage[]> {
+	send(content: string): void;
+	destroy(): void;
+}
+
+export function createChatStore(roomName: string, token: string): ChatStore {
+	const { subscribe, set, update } = writable<ChatMessage[]>([]);
+
+	let ws: WebSocket | null = null;
+	let reconnectTimeout: ReturnType<typeof setTimeout> | null = null;
+	let reconnectAttempts = 0;
+	let isTornDown = false;
+	const baseDelayMs = 1000;
+	const maxDelayMs = 30000;
+
+	function connect() {
+		const wsUrl = env.PUBLIC_WS_URL;
+		if (!wsUrl) {
+			console.error('Missing PUBLIC_WS_URL');
+			return;
+		}
+		const url =
+			`${wsUrl}/ws/rooms/${encodeURIComponent(roomName)}/chat` +
+			`?token=${encodeURIComponent(token)}`;
+		ws = new WebSocket(url);
+
+		ws.onopen = () => {
+			reconnectAttempts = 0;
+		};
+
+		ws.onmessage = (event: MessageEvent<string>) => {
+			const frame = parseFrame(event.data);
+			if (!frame) {
+				console.error('Bad chat frame', event.data);
+				return;
+			}
+			if (frame.type === 'history') {
+				set(frame.messages);
+			} else {
+				update((msgs) => [...msgs, frame.message]);
+			}
+		};
+
+		ws.onclose = () => {
+			scheduleReconnect();
+		};
+
+		ws.onerror = () => {
+			ws?.close();
+		};
+	}
+
+	function scheduleReconnect() {
+		if (isTornDown) return;
+		if (reconnectTimeout) clearTimeout(reconnectTimeout);
+		const exp = Math.min(maxDelayMs, baseDelayMs * Math.pow(2, reconnectAttempts));
+		const jitter = Math.random() * (exp * 0.5);
+		reconnectAttempts += 1;
+		reconnectTimeout = setTimeout(connect, exp + jitter);
+	}
+
+	if (browser) {
+		connect();
+	}
+
+	return {
+		subscribe,
+		send(content: string) {
+			const trimmed = content.trim();
+			if (!trimmed || !ws || ws.readyState !== WebSocket.OPEN) return;
+			ws.send(JSON.stringify({ content: trimmed }));
+		},
+		destroy() {
+			isTornDown = true;
+			if (reconnectTimeout) clearTimeout(reconnectTimeout);
+			if (ws && (ws.readyState === WebSocket.OPEN || ws.readyState === WebSocket.CONNECTING)) {
+				ws.close();
+			}
+		}
+	};
+}

--- a/frontend/src/routes/auth/+page.svelte
+++ b/frontend/src/routes/auth/+page.svelte
@@ -69,7 +69,6 @@
 			loading = false;
 		}
 	}
-
 </script>
 
 <div class="auth-page">
@@ -103,7 +102,11 @@
 				<h3>Sign In / Register</h3>
 				<div>
 					<button onclick={handleCopy} disabled={!mnemonic}>
-						{copyStatus === 'ok' ? 'Copied ✓' : copyStatus === 'fail' ? 'Copy Failed' : 'Copy Phrase'}
+						{copyStatus === 'ok'
+							? 'Copied ✓'
+							: copyStatus === 'fail'
+								? 'Copy Failed'
+								: 'Copy Phrase'}
 					</button>
 					<button onclick={handleGenerate} disabled={loading}> Generate New Phrase </button>
 				</div>

--- a/frontend/src/routes/auth/+page.svelte
+++ b/frontend/src/routes/auth/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { generateMnemonic, authenticate } from '$lib/auth';
 	import MnemonicInput from '$lib/components/MnemonicInput.svelte';
+	import { enhance } from '$app/forms';
 	import { deserialize } from '$app/forms';
 	import { invalidateAll } from '$app/navigation';
 	import type { PageProps } from './$types';
@@ -16,10 +17,32 @@
 		error = '';
 	}
 
-	function handleCopy() {
-		if (mnemonic) {
-			navigator.clipboard.writeText(mnemonic);
+	let copyStatus = $state<'idle' | 'ok' | 'fail'>('idle');
+
+	async function handleCopy() {
+		if (!mnemonic) return;
+		try {
+			if (navigator.clipboard?.writeText) {
+				await navigator.clipboard.writeText(mnemonic);
+			} else {
+				// HTTP context blocks the async Clipboard API; fall back to the
+				// legacy textarea+execCommand path which still works there.
+				const ta = document.createElement('textarea');
+				ta.value = mnemonic;
+				ta.style.position = 'fixed';
+				ta.style.opacity = '0';
+				document.body.appendChild(ta);
+				ta.focus();
+				ta.select();
+				const ok = document.execCommand('copy');
+				document.body.removeChild(ta);
+				if (!ok) throw new Error('execCommand failed');
+			}
+			copyStatus = 'ok';
+		} catch {
+			copyStatus = 'fail';
 		}
+		setTimeout(() => (copyStatus = 'idle'), 1500);
 	}
 
 	async function startAuth() {
@@ -47,13 +70,6 @@
 		}
 	}
 
-	async function handleLogout() {
-		const response = await fetch('?/logout', { method: 'POST', body: new FormData() });
-		const actionResult = deserialize(await response.text());
-		if (actionResult.type === 'success') {
-			await invalidateAll();
-		}
-	}
 </script>
 
 <div class="auth-page">
@@ -64,10 +80,20 @@
 			<h3>Active Session</h3>
 			<p><strong>Status:</strong> Authenticated</p>
 			<p><strong>Username:</strong> <code>{data.user.username}</code></p>
-			<p><strong>Identity Address:</strong> <code>{data.user.address}</code></p>
 			<p><strong>JWT:</strong> <code class="jwt">{data.jwt}</code></p>
 
-			<button class="logout-btn" onclick={handleLogout}>Log Out / Clear Session</button>
+			<form
+				method="POST"
+				action="?/logout"
+				use:enhance={() => {
+					return async ({ update }) => {
+						await update();
+						await invalidateAll();
+					};
+				}}
+			>
+				<button class="logout-btn" type="submit">Log Out / Clear Session</button>
+			</form>
 		</div>
 	{:else}
 		<p>Access your non-custodial profile using your recovery phrase.</p>
@@ -76,7 +102,9 @@
 			<div class="auth-header">
 				<h3>Sign In / Register</h3>
 				<div>
-					<button onclick={handleCopy} disabled={!mnemonic}>Copy Phrase</button>
+					<button onclick={handleCopy} disabled={!mnemonic}>
+						{copyStatus === 'ok' ? 'Copied ✓' : copyStatus === 'fail' ? 'Copy Failed' : 'Copy Phrase'}
+					</button>
 					<button onclick={handleGenerate} disabled={loading}> Generate New Phrase </button>
 				</div>
 			</div>

--- a/frontend/src/routes/rooms/+page.server.ts
+++ b/frontend/src/routes/rooms/+page.server.ts
@@ -5,11 +5,7 @@ import { fail } from '@sveltejs/kit';
 import { jwtDecode } from 'jwt-decode';
 
 function backendBase(): string {
-	return (
-		privateEnv.BACKEND_INTERNAL_URL ||
-		env.PUBLIC_BACKEND_URL ||
-		'http://localhost:8000'
-	);
+	return privateEnv.BACKEND_INTERNAL_URL || env.PUBLIC_BACKEND_URL || 'http://localhost:8000';
 }
 
 interface SessionTokenClaims {

--- a/frontend/src/routes/rooms/+page.server.ts
+++ b/frontend/src/routes/rooms/+page.server.ts
@@ -1,7 +1,16 @@
 import type { Actions, PageServerLoad } from './$types';
 import { env } from '$env/dynamic/public';
+import { env as privateEnv } from '$env/dynamic/private';
 import { fail } from '@sveltejs/kit';
 import { jwtDecode } from 'jwt-decode';
+
+function backendBase(): string {
+	return (
+		privateEnv.BACKEND_INTERNAL_URL ||
+		env.PUBLIC_BACKEND_URL ||
+		'http://localhost:8000'
+	);
+}
 
 interface SessionTokenClaims {
 	sub?: string;
@@ -30,7 +39,7 @@ export const load: PageServerLoad = async ({ cookies }) => {
 	}
 
 	try {
-		const baseUrl = env.PUBLIC_BACKEND_URL || 'http://localhost:8000';
+		const baseUrl = backendBase();
 		const response = await fetch(`${baseUrl}/games`);
 
 		if (response.ok) {
@@ -67,7 +76,7 @@ export const actions: Actions = {
 		console.log('creating room', name, game, players_max);
 
 		try {
-			const baseUrl = env.PUBLIC_BACKEND_URL || 'http://localhost:8000';
+			const baseUrl = backendBase();
 			const res = await fetch(`${baseUrl}/rooms`, {
 				method: 'POST',
 				headers: {
@@ -101,7 +110,7 @@ export const actions: Actions = {
 		if (!room_name) return fail(400, { error: 'Missing room name' });
 
 		try {
-			const baseUrl = env.PUBLIC_BACKEND_URL || 'http://localhost:8000';
+			const baseUrl = backendBase();
 			const res = await fetch(`${baseUrl}/rooms/${encodeURIComponent(room_name.toString())}/join`, {
 				method: 'POST',
 				headers: { Authorization: `Bearer ${session}` }
@@ -127,7 +136,7 @@ export const actions: Actions = {
 		if (!room_name) return fail(400, { error: 'Missing room name' });
 
 		try {
-			const baseUrl = env.PUBLIC_BACKEND_URL || 'http://localhost:8000';
+			const baseUrl = backendBase();
 			const res = await fetch(
 				`${baseUrl}/rooms/${encodeURIComponent(room_name.toString())}/leave`,
 				{

--- a/frontend/src/routes/rooms/+page.svelte
+++ b/frontend/src/routes/rooms/+page.svelte
@@ -224,6 +224,12 @@
 												[ LEAVE ]
 											</button>
 										</form>
+
+										{#if isMember}
+											<a class="card-btn open" href="/rooms/{encodeURIComponent(room.name)}">
+												[ OPEN ]
+											</a>
+										{/if}
 									</div>
 								{/if}
 							</div>
@@ -701,6 +707,20 @@
 	.card-btn.leave:hover:not(:disabled) {
 		border-color: #ff6b6b;
 		color: #ff6b6b;
+	}
+
+	.card-btn.open {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		text-decoration: none;
+		color: #e3bc74;
+		border-color: #3d3930;
+	}
+
+	.card-btn.open:hover {
+		border-color: #e3bc74;
+		background: rgba(227, 188, 116, 0.08);
 	}
 
 	.card-btn:disabled {

--- a/frontend/src/routes/rooms/+page.svelte
+++ b/frontend/src/routes/rooms/+page.svelte
@@ -677,7 +677,8 @@
 		margin-top: 1rem;
 	}
 
-	.card-actions form {
+	.card-actions form,
+	.card-actions > .card-btn.open {
 		flex: 1;
 	}
 

--- a/frontend/src/routes/rooms/[name]/+page.server.ts
+++ b/frontend/src/routes/rooms/[name]/+page.server.ts
@@ -1,0 +1,68 @@
+import type { PageServerLoad } from './$types';
+import { env } from '$env/dynamic/public';
+import { env as privateEnv } from '$env/dynamic/private';
+import { redirect } from '@sveltejs/kit';
+import { jwtDecode } from 'jwt-decode';
+
+function backendBase(): string {
+	return (
+		privateEnv.BACKEND_INTERNAL_URL ||
+		env.PUBLIC_BACKEND_URL ||
+		'http://localhost:8000'
+	);
+}
+
+interface SessionTokenClaims {
+	sub?: string;
+	username?: string;
+}
+
+interface RoomDetail {
+	name: string;
+	game: string;
+	players_max: number;
+	players_active: number;
+	member_addresses: string[];
+	expires_at: string;
+}
+
+export const load: PageServerLoad = async ({ params, cookies }) => {
+	const session = cookies.get('session');
+	if (!session) throw redirect(303, '/auth');
+
+	let address: string | null = null;
+	let username = 'Unknown';
+	try {
+		const claims = jwtDecode<SessionTokenClaims>(session);
+		if (claims?.sub) address = claims.sub;
+		if (claims?.username) username = claims.username;
+	} catch {
+		throw redirect(303, '/auth');
+	}
+	if (!address) throw redirect(303, '/auth');
+
+	const baseUrl = backendBase();
+	let isMember = false;
+	let roomGame = '';
+	try {
+		const res = await fetch(`${baseUrl}/rooms/${encodeURIComponent(params.name)}`);
+		if (res.ok) {
+			const data = (await res.json()) as RoomDetail;
+			roomGame = data.game;
+			const lower = address.toLowerCase();
+			isMember = data.member_addresses.some((a) => a.toLowerCase() === lower);
+		}
+	} catch {
+		// treat fetch errors as non-member; will redirect below
+	}
+
+	if (!isMember) throw redirect(303, '/rooms');
+
+	return {
+		roomName: params.name,
+		roomGame,
+		token: session,
+		address,
+		username
+	};
+};

--- a/frontend/src/routes/rooms/[name]/+page.server.ts
+++ b/frontend/src/routes/rooms/[name]/+page.server.ts
@@ -5,11 +5,7 @@ import { redirect } from '@sveltejs/kit';
 import { jwtDecode } from 'jwt-decode';
 
 function backendBase(): string {
-	return (
-		privateEnv.BACKEND_INTERNAL_URL ||
-		env.PUBLIC_BACKEND_URL ||
-		'http://localhost:8000'
-	);
+	return privateEnv.BACKEND_INTERNAL_URL || env.PUBLIC_BACKEND_URL || 'http://localhost:8000';
 }
 
 interface SessionTokenClaims {

--- a/frontend/src/routes/rooms/[name]/+page.svelte
+++ b/frontend/src/routes/rooms/[name]/+page.svelte
@@ -1,0 +1,238 @@
+<script lang="ts">
+	import { onDestroy, onMount, tick } from 'svelte';
+	import type { PageData } from './$types';
+	import { createChatStore, type ChatMessage, type ChatStore } from '$lib/chatStore';
+
+	let { data }: { data: PageData } = $props();
+
+	let chat = $state<ChatStore | null>(null);
+	let messages = $state<ChatMessage[]>([]);
+	let input = $state('');
+	let scroller: HTMLDivElement | null = $state(null);
+
+	onMount(() => {
+		const store = createChatStore(data.roomName, data.token);
+		chat = store;
+		const unsubscribe = store.subscribe(async (m) => {
+			messages = m;
+			await tick();
+			if (scroller) scroller.scrollTop = scroller.scrollHeight;
+		});
+		return unsubscribe;
+	});
+
+	onDestroy(() => {
+		chat?.destroy();
+	});
+
+	function send() {
+		if (!chat || !input.trim()) return;
+		chat.send(input);
+		input = '';
+	}
+
+	function onKey(e: KeyboardEvent) {
+		if (e.key === 'Enter' && !e.shiftKey) {
+			e.preventDefault();
+			send();
+		}
+	}
+
+	function shortAddr(addr: string): string {
+		if (addr.length <= 10) return addr;
+		return `${addr.slice(0, 6)}…${addr.slice(-4)}`;
+	}
+
+	function fmtTime(iso: string): string {
+		try {
+			return new Date(iso).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+		} catch {
+			return '';
+		}
+	}
+</script>
+
+<section class="page">
+	<header>
+		<a class="back" href="/rooms">← Rooms</a>
+		<div class="title">
+			<h1>{data.roomName}</h1>
+			{#if data.roomGame}<span class="game">{data.roomGame}</span>{/if}
+		</div>
+	</header>
+
+	<div class="chat" bind:this={scroller}>
+		{#if messages.length === 0}
+			<p class="empty">No messages yet. Say hi.</p>
+		{:else}
+			{#each messages as msg (msg.id)}
+				<article class="msg" class:mine={msg.sender_address.toLowerCase() === data.address.toLowerCase()}>
+					<div class="meta">
+						<span class="user">{msg.sender_username || shortAddr(msg.sender_address)}</span>
+						<span class="time">{fmtTime(msg.created_at)}</span>
+					</div>
+					<div class="content">{msg.content}</div>
+				</article>
+			{/each}
+		{/if}
+	</div>
+
+	<form
+		class="composer"
+		onsubmit={(e) => {
+			e.preventDefault();
+			send();
+		}}
+	>
+		<input
+			type="text"
+			placeholder="Message…"
+			bind:value={input}
+			onkeydown={onKey}
+			maxlength={1000}
+			autocomplete="off"
+		/>
+		<button type="submit" disabled={!input.trim()}>Send</button>
+	</form>
+</section>
+
+<style>
+	.page {
+		max-width: 760px;
+		margin: 0 auto;
+		padding: 1.5rem 1rem;
+		display: flex;
+		flex-direction: column;
+		gap: 1rem;
+		min-height: calc(100vh - 4rem);
+	}
+
+	header {
+		display: flex;
+		flex-direction: column;
+		gap: 0.5rem;
+	}
+
+	.back {
+		color: #e3bc74;
+		text-decoration: none;
+		font-size: 0.9rem;
+		opacity: 0.8;
+	}
+	.back:hover {
+		opacity: 1;
+	}
+
+	.title {
+		display: flex;
+		align-items: baseline;
+		gap: 0.75rem;
+	}
+
+	h1 {
+		margin: 0;
+		font-size: 1.6rem;
+		color: #f4ecd8;
+	}
+
+	.game {
+		color: #e3bc74;
+		font-size: 0.9rem;
+		opacity: 0.85;
+	}
+
+	.chat {
+		flex: 1;
+		min-height: 50vh;
+		max-height: 65vh;
+		overflow-y: auto;
+		padding: 1rem;
+		background: rgba(255, 255, 255, 0.03);
+		border: 1px solid rgba(227, 188, 116, 0.2);
+		border-radius: 12px;
+		display: flex;
+		flex-direction: column;
+		gap: 0.6rem;
+	}
+
+	.empty {
+		margin: auto;
+		color: rgba(244, 236, 216, 0.5);
+		font-style: italic;
+	}
+
+	.msg {
+		display: flex;
+		flex-direction: column;
+		gap: 0.15rem;
+		max-width: 85%;
+		padding: 0.5rem 0.75rem;
+		background: rgba(0, 0, 0, 0.25);
+		border-left: 2px solid rgba(227, 188, 116, 0.4);
+		border-radius: 6px;
+	}
+
+	.msg.mine {
+		align-self: flex-end;
+		border-left: none;
+		border-right: 2px solid #e3bc74;
+		background: rgba(227, 188, 116, 0.08);
+	}
+
+	.meta {
+		display: flex;
+		gap: 0.5rem;
+		font-size: 0.75rem;
+		opacity: 0.7;
+	}
+
+	.user {
+		color: #e3bc74;
+		font-weight: 600;
+	}
+
+	.time {
+		color: rgba(244, 236, 216, 0.5);
+	}
+
+	.content {
+		color: #f4ecd8;
+		word-wrap: break-word;
+		white-space: pre-wrap;
+	}
+
+	.composer {
+		display: flex;
+		gap: 0.5rem;
+	}
+
+	.composer input {
+		flex: 1;
+		padding: 0.65rem 0.9rem;
+		background: rgba(255, 255, 255, 0.05);
+		border: 1px solid rgba(227, 188, 116, 0.3);
+		border-radius: 8px;
+		color: #f4ecd8;
+		font-size: 0.95rem;
+	}
+
+	.composer input:focus {
+		outline: none;
+		border-color: #e3bc74;
+	}
+
+	.composer button {
+		padding: 0.65rem 1.2rem;
+		background: #e3bc74;
+		color: #0d0d0d;
+		border: none;
+		border-radius: 8px;
+		font-weight: 600;
+		cursor: pointer;
+	}
+
+	.composer button:disabled {
+		opacity: 0.4;
+		cursor: not-allowed;
+	}
+</style>

--- a/frontend/src/routes/rooms/[name]/+page.svelte
+++ b/frontend/src/routes/rooms/[name]/+page.svelte
@@ -66,7 +66,10 @@
 			<p class="empty">No messages yet. Say hi.</p>
 		{:else}
 			{#each messages as msg (msg.id)}
-				<article class="msg" class:mine={msg.sender_address.toLowerCase() === data.address.toLowerCase()}>
+				<article
+					class="msg"
+					class:mine={msg.sender_address.toLowerCase() === data.address.toLowerCase()}
+				>
 					<div class="meta">
 						<span class="user">{msg.sender_username || shortAddr(msg.sender_address)}</span>
 						<span class="time">{fmtTime(msg.created_at)}</span>


### PR DESCRIPTION
Closes #53.

Adds per-room realtime chat: `Message` model + alembic migration, JWT-gated WS endpoint with membership checks, 50-message history on connect, and a SvelteKit `/rooms/[name]` route with a chat store and message composer. Default room TTL bumped from 1m to 60m so chats are testable.

Also wires `BACKEND_INTERNAL_URL` for SSR, adds `ORIGIN` to docker-compose / deploy env so SvelteKit CSRF passes locally and on `playlink.bartek.monster`, and equalizes the JOIN/LEAVE/OPEN button widths on the rooms page.