### PR TITLE
feat(rooms): room metadata (description, communicator link, requirements)

### DIFF
--- a/backend/alembic/versions/17b0946aadca_add_room_metadata.py
+++ b/backend/alembic/versions/17b0946aadca_add_room_metadata.py
@@ -1,0 +1,53 @@
+"""add room metadata
+
+Revision ID: 17b0946aadca
+Revises: a1b2c3d4e5f6
+Create Date: 2026-05-08 13:33:01.114422
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+import sqlmodel
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "17b0946aadca"
+down_revision: str | None = "a1b2c3d4e5f6"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "room",
+        sa.Column(
+            "description",
+            sqlmodel.sql.sqltypes.AutoString(length=500),
+            nullable=True,
+        ),
+    )
+    op.add_column(
+        "room",
+        sa.Column(
+            "communicator_link",
+            sqlmodel.sql.sqltypes.AutoString(length=500),
+            nullable=True,
+        ),
+    )
+    op.add_column(
+        "room",
+        sa.Column(
+            "requirements",
+            sqlmodel.sql.sqltypes.AutoString(length=1000),
+            nullable=True,
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("room", "requirements")
+    op.drop_column("room", "communicator_link")
+    op.drop_column("room", "description")

--- a/backend/main.py
+++ b/backend/main.py
@@ -15,7 +15,8 @@ from eth_utils.address import to_checksum_address
 from fastapi import Depends, FastAPI, HTTPException, WebSocket, WebSocketDisconnect
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.security import OAuth2PasswordBearer
-from pydantic import BaseModel
+from pydantic import BaseModel, HttpUrl
+from pydantic import Field as PydField
 from sqlmodel import Session, select
 
 from database import get_session
@@ -51,6 +52,9 @@ class CreateRoomRequest(BaseModel):
     name: str
     game: str
     players_max: int
+    description: str | None = PydField(default=None, max_length=500)
+    communicator_link: HttpUrl | None = None
+    requirements: str | None = PydField(default=None, max_length=1000)
 
 
 # --- WebSocket connection manager ---
@@ -123,6 +127,9 @@ def get_rooms_payload(session: Session) -> str:
                 "players_active": len(r.members),
                 "players_max": r.players_max,
                 "member_addresses": [m.identity_address for m in r.members],
+                "description": r.description,
+                "communicator_link": r.communicator_link,
+                "requirements": r.requirements,
                 "expires_at": (
                     r.expires_at.isoformat() + "Z"
                     if r.expires_at.tzinfo is None
@@ -370,6 +377,9 @@ def get_room(room_name: str, session: SessionDep):
         "players_max": room.players_max,
         "players_active": len(room.members),
         "member_addresses": [m.identity_address for m in room.members],
+        "description": room.description,
+        "communicator_link": room.communicator_link,
+        "requirements": room.requirements,
         "expires_at": (
             room.expires_at.isoformat() + "Z"
             if room.expires_at.tzinfo is None
@@ -423,6 +433,11 @@ async def create_room(
         name=body.name,
         game=body.game,
         players_max=body.players_max,
+        description=body.description,
+        communicator_link=(
+            str(body.communicator_link) if body.communicator_link else None
+        ),
+        requirements=body.requirements,
         created_by=address,
     )
 

--- a/backend/models.py
+++ b/backend/models.py
@@ -15,6 +15,9 @@ class Room(SQLModel, table=True):
     name: str = Field(index=True, unique=True)
     game: str
     players_max: int
+    description: str | None = Field(default=None, max_length=500)
+    communicator_link: str | None = Field(default=None, max_length=500)
+    requirements: str | None = Field(default=None, max_length=1000)
     created_by: str = Field(index=True)  # identity_address of creator
     created_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
     expires_at: datetime = Field(

--- a/backend/tests/test_rooms.py
+++ b/backend/tests/test_rooms.py
@@ -1,0 +1,125 @@
+import os
+from datetime import UTC, datetime, timedelta
+
+import jwt
+from eth_account import Account
+from fastapi.testclient import TestClient
+from sqlmodel import Session
+
+
+def _auth_headers() -> tuple[dict[str, str], str]:
+    acct = Account.create()
+    address = acct.address
+    secret = os.environ["JWT_SECRET"]
+    payload = {
+        "sub": address,
+        "username": "tester",
+        "iat": datetime.now(UTC),
+        "exp": datetime.now(UTC) + timedelta(minutes=5),
+        "iss": "playlink-auth",
+    }
+    token = jwt.encode(payload, secret, algorithm="HS256")
+    return {"Authorization": f"Bearer {token}"}, address
+
+
+def _create_user(session: Session, address: str) -> None:
+    from models import User
+
+    session.add(User(identity_address=address))
+    session.commit()
+
+
+def test_create_room_with_metadata(client: TestClient, session: Session):
+    headers, address = _auth_headers()
+    _create_user(session, address)
+
+    body = {
+        "name": "lobby-1",
+        "game": "Quake III Arena",
+        "players_max": 4,
+        "description": "Friday rocket arena, casual",
+        "communicator_link": "https://discord.gg/example",
+        "requirements": "CPMA mod, latest patch",
+    }
+    res = client.post("/rooms", json=body, headers=headers)
+    assert res.status_code == 201
+
+    res = client.get("/rooms/lobby-1")
+    assert res.status_code == 200
+    data = res.json()
+    assert data["description"] == body["description"]
+    assert data["communicator_link"] == "https://discord.gg/example"
+    assert data["requirements"] == body["requirements"]
+
+
+def test_create_room_without_metadata_returns_nulls(
+    client: TestClient, session: Session
+):
+    headers, address = _auth_headers()
+    _create_user(session, address)
+
+    body = {"name": "lobby-2", "game": "Diablo II", "players_max": 8}
+    res = client.post("/rooms", json=body, headers=headers)
+    assert res.status_code == 201
+
+    res = client.get("/rooms/lobby-2")
+    assert res.status_code == 200
+    data = res.json()
+    assert data["description"] is None
+    assert data["communicator_link"] is None
+    assert data["requirements"] is None
+
+
+def test_create_room_rejects_invalid_communicator_url(
+    client: TestClient, session: Session
+):
+    headers, address = _auth_headers()
+    _create_user(session, address)
+
+    body = {
+        "name": "lobby-3",
+        "game": "StarCraft",
+        "players_max": 2,
+        "communicator_link": "not a url",
+    }
+    res = client.post("/rooms", json=body, headers=headers)
+    assert res.status_code == 422
+
+
+def test_create_room_rejects_oversized_description(
+    client: TestClient, session: Session
+):
+    headers, address = _auth_headers()
+    _create_user(session, address)
+
+    body = {
+        "name": "lobby-4",
+        "game": "Half-Life",
+        "players_max": 4,
+        "description": "x" * 501,
+    }
+    res = client.post("/rooms", json=body, headers=headers)
+    assert res.status_code == 422
+
+
+def test_list_rooms_includes_metadata(client: TestClient, session: Session):
+    headers, address = _auth_headers()
+    _create_user(session, address)
+
+    body = {
+        "name": "lobby-5",
+        "game": "Unreal Tournament",
+        "players_max": 6,
+        "description": "shown in list",
+        "communicator_link": "https://example.com/chat",
+        "requirements": "mouse + keyboard",
+    }
+    client.post("/rooms", json=body, headers=headers)
+
+    res = client.get("/rooms")
+    assert res.status_code == 200
+    rooms = res.json()
+    target = next(r for r in rooms if r["name"] == "lobby-5")
+    assert target["description"] == "shown in list"
+    assert target["communicator_link"] == "https://example.com/chat"
+    assert target["requirements"] == "mouse + keyboard"

--- a/frontend/src/lib/roomsStore.ts
+++ b/frontend/src/lib/roomsStore.ts
@@ -8,7 +8,14 @@ export interface RoomSummary {
 	players_active: number;
 	players_max: number;
 	member_addresses: string[];
+	description: string | null;
+	communicator_link: string | null;
+	requirements: string | null;
 	expires_at: string;
+}
+
+function isNullableString(value: unknown): value is string | null {
+	return value === null || typeof value === 'string';
 }
 
 function isRoomSummary(value: unknown): value is RoomSummary {
@@ -24,6 +31,9 @@ function isRoomSummary(value: unknown): value is RoomSummary {
 		typeof room.players_active === 'number' &&
 		typeof room.players_max === 'number' &&
 		Array.isArray(room.member_addresses) &&
+		isNullableString(room.description) &&
+		isNullableString(room.communicator_link) &&
+		isNullableString(room.requirements) &&
 		typeof room.expires_at === 'string'
 	);
 }

--- a/frontend/src/routes/rooms/+page.server.ts
+++ b/frontend/src/routes/rooms/+page.server.ts
@@ -64,12 +64,19 @@ export const actions: Actions = {
 		const name = data.get('name');
 		const game = data.get('game');
 		const players_max = data.get('players_max');
+		const description = data.get('description');
+		const communicator_link = data.get('communicator_link');
+		const requirements = data.get('requirements');
 
 		if (!name || !game || !players_max) {
 			return fail(400, { error: 'Missing required fields' });
 		}
 
-		console.log('creating room', name, game, players_max);
+		const optionalText = (value: FormDataEntryValue | null): string | null => {
+			if (typeof value !== 'string') return null;
+			const trimmed = value.trim();
+			return trimmed.length > 0 ? trimmed : null;
+		};
 
 		try {
 			const baseUrl = backendBase();
@@ -82,7 +89,10 @@ export const actions: Actions = {
 				body: JSON.stringify({
 					name: name.toString(),
 					game: game.toString(),
-					players_max: parseInt(players_max.toString(), 10)
+					players_max: parseInt(players_max.toString(), 10),
+					description: optionalText(description),
+					communicator_link: optionalText(communicator_link),
+					requirements: optionalText(requirements)
 				})
 			});
 

--- a/frontend/src/routes/rooms/+page.svelte
+++ b/frontend/src/routes/rooms/+page.svelte
@@ -168,6 +168,39 @@
 							/>
 						</div>
 
+						<div class="form-group">
+							<label for="description">Description (optional)</label>
+							<textarea
+								id="description"
+								name="description"
+								maxlength="500"
+								rows="3"
+								placeholder="Short note about the session"
+							></textarea>
+						</div>
+
+						<div class="form-group">
+							<label for="communicator_link">Communicator Link (optional)</label>
+							<input
+								type="url"
+								id="communicator_link"
+								name="communicator_link"
+								maxlength="500"
+								placeholder="https://discord.gg/..."
+							/>
+						</div>
+
+						<div class="form-group">
+							<label for="requirements">Requirements (optional)</label>
+							<textarea
+								id="requirements"
+								name="requirements"
+								maxlength="1000"
+								rows="3"
+								placeholder="Game version, mods, network setup..."
+							></textarea>
+						</div>
+
 						<button type="submit" class="btn btn-primary" style="margin-top: 1rem;"
 							>BROADCAST</button
 						>
@@ -643,7 +676,8 @@
 	}
 
 	.form-group input,
-	.form-group select {
+	.form-group select,
+	.form-group textarea {
 		width: 100%;
 		background: #141415;
 		border: 1px solid #28251e;
@@ -654,8 +688,14 @@
 		font-size: 0.9rem;
 	}
 
+	.form-group textarea {
+		resize: vertical;
+		min-height: 3rem;
+	}
+
 	.form-group input:focus,
-	.form-group select:focus {
+	.form-group select:focus,
+	.form-group textarea:focus {
 		outline: none;
 		border-color: #e3bc74;
 	}

--- a/frontend/src/routes/rooms/[name]/+page.server.ts
+++ b/frontend/src/routes/rooms/[name]/+page.server.ts
@@ -19,6 +19,9 @@ interface RoomDetail {
 	players_max: number;
 	players_active: number;
 	member_addresses: string[];
+	description: string | null;
+	communicator_link: string | null;
+	requirements: string | null;
 	expires_at: string;
 }
 
@@ -40,11 +43,17 @@ export const load: PageServerLoad = async ({ params, cookies }) => {
 	const baseUrl = backendBase();
 	let isMember = false;
 	let roomGame = '';
+	let description: string | null = null;
+	let communicatorLink: string | null = null;
+	let requirements: string | null = null;
 	try {
 		const res = await fetch(`${baseUrl}/rooms/${encodeURIComponent(params.name)}`);
 		if (res.ok) {
 			const data = (await res.json()) as RoomDetail;
 			roomGame = data.game;
+			description = data.description;
+			communicatorLink = data.communicator_link;
+			requirements = data.requirements;
 			const lower = address.toLowerCase();
 			isMember = data.member_addresses.some((a) => a.toLowerCase() === lower);
 		}
@@ -57,6 +66,9 @@ export const load: PageServerLoad = async ({ params, cookies }) => {
 	return {
 		roomName: params.name,
 		roomGame,
+		description,
+		communicatorLink,
+		requirements,
 		token: session,
 		address,
 		username

--- a/frontend/src/routes/rooms/[name]/+page.svelte
+++ b/frontend/src/routes/rooms/[name]/+page.svelte
@@ -59,6 +59,30 @@
 			<h1>{data.roomName}</h1>
 			{#if data.roomGame}<span class="game">{data.roomGame}</span>{/if}
 		</div>
+		{#if data.description || data.communicatorLink || data.requirements}
+			<div class="meta-block">
+				{#if data.description}
+					<div class="meta-item">
+						<span class="meta-label">Description</span>
+						<p class="meta-value">{data.description}</p>
+					</div>
+				{/if}
+				{#if data.communicatorLink}
+					<div class="meta-item">
+						<span class="meta-label">Communicator</span>
+						<a class="meta-link" href={data.communicatorLink} target="_blank" rel="noopener">
+							{data.communicatorLink}
+						</a>
+					</div>
+				{/if}
+				{#if data.requirements}
+					<div class="meta-item">
+						<span class="meta-label">Requirements</span>
+						<p class="meta-value">{data.requirements}</p>
+					</div>
+				{/if}
+			</div>
+		{/if}
 	</header>
 
 	<div class="chat" bind:this={scroller}>
@@ -142,6 +166,52 @@
 		color: #e3bc74;
 		font-size: 0.9rem;
 		opacity: 0.85;
+	}
+
+	.meta-block {
+		display: flex;
+		flex-direction: column;
+		gap: 0.5rem;
+		margin-top: 0.5rem;
+		padding: 0.75rem 1rem;
+		background: rgba(255, 255, 255, 0.03);
+		border: 1px solid rgba(227, 188, 116, 0.2);
+		border-radius: 8px;
+	}
+
+	.meta-item {
+		display: flex;
+		flex-direction: column;
+		gap: 0.15rem;
+	}
+
+	.meta-label {
+		font-size: 0.7rem;
+		letter-spacing: 0.1em;
+		text-transform: uppercase;
+		color: #e3bc74;
+		opacity: 0.85;
+	}
+
+	.meta-value {
+		margin: 0;
+		color: #f4ecd8;
+		font-size: 0.9rem;
+		line-height: 1.4;
+		white-space: pre-wrap;
+		word-wrap: break-word;
+	}
+
+	.meta-link {
+		color: #f4ecd8;
+		font-size: 0.9rem;
+		word-break: break-all;
+		text-decoration: underline;
+		text-decoration-color: rgba(227, 188, 116, 0.4);
+	}
+
+	.meta-link:hover {
+		text-decoration-color: #e3bc74;
 	}
 
 	.chat {


### PR DESCRIPTION
## Summary
- Adds optional `description` (≤500), `communicator_link` (HttpUrl, ≤500) and `requirements` (≤1000) to `Room`.
- Backend: model + Alembic migration (3× nullable `ADD COLUMN`), schema validation in `CreateRoomRequest`, fields propagated through `POST /rooms`, `GET /rooms`, `GET /rooms/{name}` and the rooms WebSocket broadcast.
- Frontend: new inputs in the create-room form (empty values sent as `null`), metadata block rendered conditionally on the room detail view, `RoomSummary` type extended.
- Backwards compatible: existing rows stay valid (all columns nullable, no backfill); old API consumers keep working.

## Test plan
- [x] `pytest` — 18 passed (5 new tests in `tests/test_rooms.py`: happy path, empty optional fields, invalid URL → 422, oversized description → 422, metadata in list response)
- [x] `ruff check .` and `ruff format --check .` clean
- [x] Alembic round-trip on SQLite: `upgrade head` → `downgrade -1` → `upgrade head` clean
- [x] Manual UI smoke via Playwright against local dev (backend + SvelteKit dev):
    - [x] Create room with all 3 metadata fields → appears in list, auto-joined
    - [x] Detail view renders Description, clickable Communicator link, Requirements
    - [x] Create room with no optional fields → detail view has no metadata block
    - [x] POST with malformed `communicator_link` → backend returns 422 (`url_parsing`)

Closes #55