### PR TITLE
Feat/62 room calendar

### DIFF
--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -15,7 +15,15 @@ if env_path.exists():
 # Import models so Alembic can see the metadata
 from sqlmodel import SQLModel  # noqa: E402
 
-from models import Game, Message, Nonce, Room, User  # noqa: F401, E402
+from models import (  # noqa: F401, E402
+    Game,
+    Message,
+    Nonce,
+    Room,
+    RoomEvent,
+    RoomEventRsvp,
+    User,
+)
 
 config = context.config
 

--- a/backend/alembic/versions/4fb1ffbfc7d9_add_room_event_and_rsvp.py
+++ b/backend/alembic/versions/4fb1ffbfc7d9_add_room_event_and_rsvp.py
@@ -1,0 +1,84 @@
+"""add room event and rsvp
+
+Revision ID: 4fb1ffbfc7d9
+Revises: 17b0946aadca
+Create Date: 2026-05-27 22:14:41.377640
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+import sqlmodel
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "4fb1ffbfc7d9"
+down_revision: str | None = "17b0946aadca"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "roomevent",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("room_id", sa.Integer(), nullable=False),
+        sa.Column("starts_at", sa.DateTime(), nullable=False),
+        sa.Column("created_by", sqlmodel.sql.sqltypes.AutoString(), nullable=False),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), nullable=False),
+        sa.ForeignKeyConstraint(["room_id"], ["room.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        op.f("ix_roomevent_created_by"), "roomevent", ["created_by"], unique=False
+    )
+    op.create_index(op.f("ix_roomevent_room_id"), "roomevent", ["room_id"], unique=True)
+    op.create_index(
+        op.f("ix_roomevent_starts_at"), "roomevent", ["starts_at"], unique=False
+    )
+
+    op.create_table(
+        "roomeventrsvp",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("event_id", sa.Integer(), nullable=False),
+        sa.Column("user_id", sa.Integer(), nullable=False),
+        sa.Column(
+            "status",
+            sa.Enum("present", "absent", "maybe", name="rsvpstatus"),
+            nullable=False,
+        ),
+        sa.Column("updated_at", sa.DateTime(), nullable=False),
+        sa.ForeignKeyConstraint(["event_id"], ["roomevent.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["user_id"], ["user.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("event_id", "user_id"),
+    )
+    op.create_index(
+        op.f("ix_roomeventrsvp_event_id"),
+        "roomeventrsvp",
+        ["event_id"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_roomeventrsvp_user_id"),
+        "roomeventrsvp",
+        ["user_id"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(op.f("ix_roomeventrsvp_user_id"), table_name="roomeventrsvp")
+    op.drop_index(op.f("ix_roomeventrsvp_event_id"), table_name="roomeventrsvp")
+    op.drop_table("roomeventrsvp")
+    # Drop the named ENUM type explicitly (Postgres keeps it after drop_table;
+    # SQLite ignores this no-op).
+    sa.Enum(name="rsvpstatus").drop(op.get_bind(), checkfirst=True)
+
+    op.drop_index(op.f("ix_roomevent_starts_at"), table_name="roomevent")
+    op.drop_index(op.f("ix_roomevent_room_id"), table_name="roomevent")
+    op.drop_index(op.f("ix_roomevent_created_by"), table_name="roomevent")
+    op.drop_table("roomevent")

--- a/backend/alembic/versions/b7e2c1f4d8a3_add_event_ends_at.py
+++ b/backend/alembic/versions/b7e2c1f4d8a3_add_event_ends_at.py
@@ -1,0 +1,53 @@
+"""add ends_at to room event
+
+Revision ID: b7e2c1f4d8a3
+Revises: 4fb1ffbfc7d9
+Create Date: 2026-05-27 23:50:00.000000
+
+"""
+
+from collections.abc import Sequence
+from datetime import timedelta
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "b7e2c1f4d8a3"
+down_revision: str | None = "4fb1ffbfc7d9"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    # Add the column nullable so we can backfill existing rows, then enforce
+    # NOT NULL. New rows always provide ends_at via the API, so this is only
+    # relevant if some env already has events from the prior migration.
+    op.add_column(
+        "roomevent",
+        sa.Column("ends_at", sa.DateTime(), nullable=True),
+    )
+
+    # Backfill: assume any existing event lasts 2 hours by default.
+    bind = op.get_bind()
+    rows = bind.execute(sa.text("SELECT id, starts_at FROM roomevent")).fetchall()
+    for row_id, starts_at in rows:
+        bind.execute(
+            sa.text("UPDATE roomevent SET ends_at = :ends WHERE id = :id"),
+            {"ends": starts_at + timedelta(hours=2), "id": row_id},
+        )
+
+    # Tighten to NOT NULL. SQLite needs batch_alter_table (it rebuilds the
+    # table); Postgres handles a plain ALTER COLUMN.
+    with op.batch_alter_table("roomevent") as batch_op:
+        batch_op.alter_column("ends_at", existing_type=sa.DateTime(), nullable=False)
+
+    op.create_index(
+        op.f("ix_roomevent_ends_at"), "roomevent", ["ends_at"], unique=False
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(op.f("ix_roomevent_ends_at"), table_name="roomevent")
+    op.drop_column("roomevent", "ends_at")

--- a/backend/main.py
+++ b/backend/main.py
@@ -20,7 +20,16 @@ from pydantic import Field as PydField
 from sqlmodel import Session, select
 
 from database import get_session
-from models import Game, Message, Nonce, Room, User
+from models import (
+    Game,
+    Message,
+    Nonce,
+    Room,
+    RoomEvent,
+    RoomEventRsvp,
+    RsvpStatus,
+    User,
+)
 
 # Load .env from project root if it exists
 env_path = Path(__file__).parent.parent / ".env"
@@ -55,6 +64,18 @@ class CreateRoomRequest(BaseModel):
     description: str | None = PydField(default=None, max_length=500)
     communicator_link: HttpUrl | None = None
     requirements: str | None = PydField(default=None, max_length=1000)
+
+
+class ScheduleEventRequest(BaseModel):
+    """Body for `PUT /rooms/{name}/event`. `starts_at` must be in the future."""
+
+    starts_at: datetime
+
+
+class SetRsvpRequest(BaseModel):
+    """Body for `PUT /rooms/{name}/event/rsvp`."""
+
+    status: RsvpStatus
 
 
 # --- WebSocket connection manager ---
@@ -107,7 +128,10 @@ def hash_nonce(nonce_value: str) -> str:
 def get_rooms_payload(session: Session) -> str:
     now = datetime.now(UTC)
 
-    # Optional cleanup of expired rooms before returning the payload
+    # Optional cleanup of expired rooms before returning the payload.
+    # NOTE: The DB layer also has ON DELETE CASCADE on RoomEvent / RoomEventRsvp
+    # / Message, but we delete explicitly so the same code path works on
+    # SQLite (test environment) where FK cascades depend on PRAGMA settings.
     expired_rooms = session.exec(select(Room).where(Room.expires_at <= now)).all()
     for er in expired_rooms:
         old_messages = session.exec(
@@ -115,6 +139,16 @@ def get_rooms_payload(session: Session) -> str:
         ).all()
         for m in old_messages:
             session.delete(m)
+        old_event = session.exec(
+            select(RoomEvent).where(RoomEvent.room_id == er.id)
+        ).first()
+        if old_event is not None:
+            old_rsvps = session.exec(
+                select(RoomEventRsvp).where(RoomEventRsvp.event_id == old_event.id)
+            ).all()
+            for r in old_rsvps:
+                session.delete(r)
+            session.delete(old_event)
         session.delete(er)
     if expired_rooms:
         session.commit()
@@ -130,11 +164,7 @@ def get_rooms_payload(session: Session) -> str:
                 "description": r.description,
                 "communicator_link": r.communicator_link,
                 "requirements": r.requirements,
-                "expires_at": (
-                    r.expires_at.isoformat() + "Z"
-                    if r.expires_at.tzinfo is None
-                    else r.expires_at.isoformat()
-                ),
+                "expires_at": _iso(r.expires_at),
             }
             for r in session.exec(select(Room)).all()
         ]
@@ -166,6 +196,45 @@ async def get_current_user_address(
         raise HTTPException(status_code=401, detail="Token expired") from None
     except jwt.InvalidTokenError, KeyError:
         raise HTTPException(status_code=401, detail="Invalid token") from None
+
+
+def _iso(dt: datetime) -> str:
+    """Serialize a datetime to ISO 8601, appending `Z` for naive UTC values."""
+    return dt.isoformat() + "Z" if dt.tzinfo is None else dt.isoformat()
+
+
+def _serialize_event_state(session: Session, room: Room) -> dict | None:
+    """Build the JSON payload for a room's scheduled event.
+
+    Returns `None` when the room has no event yet. Used by both the REST
+    endpoints and the chat WebSocket so that `event_update` frames stay
+    in sync with `GET /rooms/{name}/event`.
+    """
+    event = session.exec(select(RoomEvent).where(RoomEvent.room_id == room.id)).first()
+    if event is None:
+        return None
+
+    rsvp_rows = session.exec(
+        select(RoomEventRsvp, User)
+        .join(User, User.id == RoomEventRsvp.user_id)
+        .where(RoomEventRsvp.event_id == event.id)
+    ).all()
+
+    return {
+        "starts_at": _iso(event.starts_at),
+        "created_by": event.created_by,
+        "created_at": _iso(event.created_at),
+        "updated_at": _iso(event.updated_at),
+        "rsvps": [
+            {
+                "address": user.identity_address,
+                "username": user.username,
+                "status": rsvp.status.value,
+                "updated_at": _iso(rsvp.updated_at),
+            }
+            for rsvp, user in rsvp_rows
+        ],
+    }
 
 
 DEFAULT_GAMES: list[str] = [
@@ -380,11 +449,8 @@ def get_room(room_name: str, session: SessionDep):
         "description": room.description,
         "communicator_link": room.communicator_link,
         "requirements": room.requirements,
-        "expires_at": (
-            room.expires_at.isoformat() + "Z"
-            if room.expires_at.tzinfo is None
-            else room.expires_at.isoformat()
-        ),
+        "expires_at": _iso(room.expires_at),
+        "event": _serialize_event_state(session, room),
     }
 
 
@@ -499,12 +565,205 @@ async def leave_room(
     if user not in room.members:
         raise HTTPException(status_code=400, detail="You are not in this room")
 
+    # Drop the leaving user's RSVP (if any) so an event's roster reflects
+    # the current member set. Idempotent — runs even when no event exists.
+    event = session.exec(select(RoomEvent).where(RoomEvent.room_id == room.id)).first()
+    rsvp_to_drop: RoomEventRsvp | None = None
+    if event is not None:
+        rsvp_to_drop = session.exec(
+            select(RoomEventRsvp).where(
+                RoomEventRsvp.event_id == event.id,
+                RoomEventRsvp.user_id == user.id,
+            )
+        ).first()
+        if rsvp_to_drop is not None:
+            session.delete(rsvp_to_drop)
+
     room.members.remove(user)
     session.add(room)
     session.commit()
 
     await manager.broadcast(get_rooms_payload(session))
+    if rsvp_to_drop is not None:
+        await chat_manager.broadcast(
+            room_name,
+            json.dumps(
+                {"type": "event_update", "event": _serialize_event_state(session, room)}
+            ),
+        )
     return {"status": "left", "room": room.name}
+
+
+@app.get("/rooms/{room_name}/event")
+def get_room_event(room_name: str, session: SessionDep):
+    """Return the room's scheduled event (if any), including the RSVP roster.
+
+    Mirrors `GET /rooms/{name}` in being public — anyone can browse the
+    schedule, only members are allowed to RSVP.
+    """
+    room = session.exec(select(Room).where(Room.name == room_name)).first()
+    if not room:
+        raise HTTPException(status_code=404, detail="Room not found")
+    event_state = _serialize_event_state(session, room)
+    if event_state is None:
+        raise HTTPException(status_code=404, detail="No event scheduled")
+    return event_state
+
+
+@app.put("/rooms/{room_name}/event", status_code=200)
+async def schedule_room_event(
+    room_name: str,
+    body: ScheduleEventRequest,
+    session: SessionDep,
+    address: Annotated[str, Depends(get_current_user_address)],
+):
+    """Create or replace the scheduled event for a room.
+
+    Only the room creator may schedule. `starts_at` must lie in the future
+    and before the room's `expires_at` so the event cannot outlive its room.
+    """
+    room = session.exec(select(Room).where(Room.name == room_name)).first()
+    if not room:
+        raise HTTPException(status_code=404, detail="Room not found")
+
+    if room.created_by.lower() != address.lower():
+        raise HTTPException(
+            status_code=403, detail="Only the room creator can schedule an event"
+        )
+
+    starts_at = body.starts_at
+    if starts_at.tzinfo is None:
+        starts_at = starts_at.replace(tzinfo=UTC)
+    else:
+        starts_at = starts_at.astimezone(UTC)
+
+    now = datetime.now(UTC)
+    if starts_at <= now:
+        raise HTTPException(status_code=400, detail="starts_at must be in the future")
+
+    expires_at = room.expires_at
+    if expires_at.tzinfo is None:
+        expires_at = expires_at.replace(tzinfo=UTC)
+    if starts_at >= expires_at:
+        raise HTTPException(
+            status_code=400,
+            detail="starts_at must be before the room expires",
+        )
+
+    event = session.exec(select(RoomEvent).where(RoomEvent.room_id == room.id)).first()
+    if event is None:
+        event = RoomEvent(
+            room_id=room.id,
+            starts_at=starts_at,
+            created_by=address,
+        )
+        session.add(event)
+    else:
+        event.starts_at = starts_at
+        event.updated_at = datetime.now(UTC)
+        session.add(event)
+    session.commit()
+
+    payload = _serialize_event_state(session, room)
+    await chat_manager.broadcast(
+        room_name, json.dumps({"type": "event_update", "event": payload})
+    )
+    return payload
+
+
+@app.delete("/rooms/{room_name}/event", status_code=200)
+async def cancel_room_event(
+    room_name: str,
+    session: SessionDep,
+    address: Annotated[str, Depends(get_current_user_address)],
+):
+    """Delete the scheduled event for a room and clear all RSVPs."""
+    room = session.exec(select(Room).where(Room.name == room_name)).first()
+    if not room:
+        raise HTTPException(status_code=404, detail="Room not found")
+
+    if room.created_by.lower() != address.lower():
+        raise HTTPException(
+            status_code=403, detail="Only the room creator can cancel the event"
+        )
+
+    event = session.exec(select(RoomEvent).where(RoomEvent.room_id == room.id)).first()
+    if event is None:
+        raise HTTPException(status_code=404, detail="No event scheduled")
+
+    rsvps = session.exec(
+        select(RoomEventRsvp).where(RoomEventRsvp.event_id == event.id)
+    ).all()
+    for r in rsvps:
+        session.delete(r)
+    session.delete(event)
+    session.commit()
+
+    await chat_manager.broadcast(
+        room_name, json.dumps({"type": "event_update", "event": None})
+    )
+    return {"status": "cancelled", "room": room.name}
+
+
+@app.put("/rooms/{room_name}/event/rsvp", status_code=200)
+async def set_room_event_rsvp(
+    room_name: str,
+    body: SetRsvpRequest,
+    session: SessionDep,
+    address: Annotated[str, Depends(get_current_user_address)],
+):
+    """Upsert the caller's RSVP for the room's scheduled event.
+
+    Only current members of the room may RSVP. The caller's status
+    overwrites any previous one (one RSVP per user per event).
+    """
+    room = session.exec(select(Room).where(Room.name == room_name)).first()
+    if not room:
+        raise HTTPException(status_code=404, detail="Room not found")
+
+    user = session.exec(select(User).where(User.identity_address == address)).first()
+    if not user:
+        raise HTTPException(status_code=404, detail="User not found")
+
+    if user not in room.members:
+        raise HTTPException(
+            status_code=403, detail="Only room members can RSVP to the event"
+        )
+
+    event = session.exec(select(RoomEvent).where(RoomEvent.room_id == room.id)).first()
+    if event is None:
+        raise HTTPException(status_code=404, detail="No event scheduled")
+
+    rsvp = session.exec(
+        select(RoomEventRsvp).where(
+            RoomEventRsvp.event_id == event.id,
+            RoomEventRsvp.user_id == user.id,
+        )
+    ).first()
+    if rsvp is None:
+        rsvp = RoomEventRsvp(
+            event_id=event.id,
+            user_id=user.id,
+            status=body.status,
+        )
+        session.add(rsvp)
+    else:
+        rsvp.status = body.status
+        rsvp.updated_at = datetime.now(UTC)
+        session.add(rsvp)
+    session.commit()
+    session.refresh(rsvp)
+
+    rsvp_payload = {
+        "address": user.identity_address,
+        "username": user.username,
+        "status": rsvp.status.value,
+        "updated_at": _iso(rsvp.updated_at),
+    }
+    await chat_manager.broadcast(
+        room_name, json.dumps({"type": "rsvp_update", "rsvp": rsvp_payload})
+    )
+    return rsvp_payload
 
 
 @app.websocket("/ws/rooms")
@@ -519,14 +778,12 @@ async def websocket_rooms(websocket: WebSocket, session: SessionDep):
 
 
 def _msg_dict(msg: Message, sender_username: str) -> dict:
-    created = msg.created_at
-    iso = created.isoformat() + "Z" if created.tzinfo is None else created.isoformat()
     return {
         "id": msg.id,
         "sender_address": msg.sender_address,
         "sender_username": sender_username,
         "content": msg.content,
-        "created_at": iso,
+        "created_at": _iso(msg.created_at),
     }
 
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -449,6 +449,7 @@ def get_room(room_name: str, session: SessionDep):
         "description": room.description,
         "communicator_link": room.communicator_link,
         "requirements": room.requirements,
+        "created_by": room.created_by,
         "expires_at": _iso(room.expires_at),
         "event": _serialize_event_state(session, room),
     }

--- a/backend/main.py
+++ b/backend/main.py
@@ -670,9 +670,7 @@ async def schedule_room_event(
     if starts_at <= now:
         raise HTTPException(status_code=400, detail="starts_at must be in the future")
     if ends_at <= starts_at:
-        raise HTTPException(
-            status_code=400, detail="ends_at must be after starts_at"
-        )
+        raise HTTPException(status_code=400, detail="ends_at must be after starts_at")
 
     # Keep the room alive for the entire event plus a 30-minute grace period
     # so members don't get prune'd out mid-session.

--- a/backend/main.py
+++ b/backend/main.py
@@ -67,9 +67,10 @@ class CreateRoomRequest(BaseModel):
 
 
 class ScheduleEventRequest(BaseModel):
-    """Body for `PUT /rooms/{name}/event`. `starts_at` must be in the future."""
+    """Body for `PUT /rooms/{name}/event`. Both timestamps must be in the future."""
 
     starts_at: datetime
+    ends_at: datetime
 
 
 class SetRsvpRequest(BaseModel):
@@ -222,6 +223,7 @@ def _serialize_event_state(session: Session, room: Room) -> dict | None:
 
     return {
         "starts_at": _iso(event.starts_at),
+        "ends_at": _iso(event.ends_at),
         "created_by": event.created_by,
         "created_at": _iso(event.created_at),
         "updated_at": _iso(event.updated_at),
@@ -446,6 +448,10 @@ def get_room(room_name: str, session: SessionDep):
         "players_max": room.players_max,
         "players_active": len(room.members),
         "member_addresses": [m.identity_address for m in room.members],
+        "members": [
+            {"address": m.identity_address, "username": m.username}
+            for m in room.members
+        ],
         "description": room.description,
         "communicator_link": room.communicator_link,
         "requirements": room.requirements,
@@ -621,7 +627,9 @@ async def schedule_room_event(
     """Create or replace the scheduled event for a room.
 
     Only the room creator may schedule. `starts_at` must lie in the future
-    and before the room's `expires_at` so the event cannot outlive its room.
+    and `ends_at` must come after `starts_at`. The room's `expires_at` is
+    automatically extended past `ends_at` so the room stays alive until the
+    event finishes (plus a small grace period for stragglers).
     """
     room = session.exec(select(Room).where(Room.name == room_name)).first()
     if not room:
@@ -633,34 +641,48 @@ async def schedule_room_event(
         )
 
     starts_at = body.starts_at
+    ends_at = body.ends_at
     if starts_at.tzinfo is None:
         starts_at = starts_at.replace(tzinfo=UTC)
     else:
         starts_at = starts_at.astimezone(UTC)
+    if ends_at.tzinfo is None:
+        ends_at = ends_at.replace(tzinfo=UTC)
+    else:
+        ends_at = ends_at.astimezone(UTC)
 
     now = datetime.now(UTC)
     if starts_at <= now:
         raise HTTPException(status_code=400, detail="starts_at must be in the future")
+    if ends_at <= starts_at:
+        raise HTTPException(
+            status_code=400, detail="ends_at must be after starts_at"
+        )
 
+    # Keep the room alive for the entire event plus a 30-minute grace period
+    # so members don't get prune'd out mid-session.
+    grace = timedelta(minutes=30)
     expires_at = room.expires_at
     if expires_at.tzinfo is None:
         expires_at = expires_at.replace(tzinfo=UTC)
-    if starts_at >= expires_at:
-        raise HTTPException(
-            status_code=400,
-            detail="starts_at must be before the room expires",
-        )
+    new_expiry = max(expires_at, ends_at + grace)
+    room_expiry_changed = new_expiry != expires_at
+    if room_expiry_changed:
+        room.expires_at = new_expiry
+        session.add(room)
 
     event = session.exec(select(RoomEvent).where(RoomEvent.room_id == room.id)).first()
     if event is None:
         event = RoomEvent(
             room_id=room.id,
             starts_at=starts_at,
+            ends_at=ends_at,
             created_by=address,
         )
         session.add(event)
     else:
         event.starts_at = starts_at
+        event.ends_at = ends_at
         event.updated_at = datetime.now(UTC)
         session.add(event)
     session.commit()
@@ -669,6 +691,8 @@ async def schedule_room_event(
     await chat_manager.broadcast(
         room_name, json.dumps({"type": "event_update", "event": payload})
     )
+    if room_expiry_changed:
+        await manager.broadcast(get_rooms_payload(session))
     return payload
 
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -204,6 +204,13 @@ def _iso(dt: datetime) -> str:
     return dt.isoformat() + "Z" if dt.tzinfo is None else dt.isoformat()
 
 
+def _members_payload(room: Room) -> list[dict[str, str]]:
+    """Compact roster for chat WS `roster_update` frames."""
+    return [
+        {"address": m.identity_address, "username": m.username} for m in room.members
+    ]
+
+
 def _serialize_event_state(session: Session, room: Room) -> dict | None:
     """Build the JSON payload for a room's scheduled event.
 
@@ -552,6 +559,10 @@ async def join_room(
     session.commit()
 
     await manager.broadcast(get_rooms_payload(session))
+    await chat_manager.broadcast(
+        room_name,
+        json.dumps({"type": "roster_update", "members": _members_payload(room)}),
+    )
     return {"status": "joined", "room": room.name}
 
 
@@ -591,6 +602,10 @@ async def leave_room(
     session.commit()
 
     await manager.broadcast(get_rooms_payload(session))
+    await chat_manager.broadcast(
+        room_name,
+        json.dumps({"type": "roster_update", "members": _members_payload(room)}),
+    )
     if rsvp_to_drop is not None:
         await chat_manager.broadcast(
             room_name,

--- a/backend/models.py
+++ b/backend/models.py
@@ -64,6 +64,7 @@ class RoomEvent(SQLModel, table=True):
         ),
     )
     starts_at: datetime = Field(index=True)
+    ends_at: datetime = Field(index=True)
     created_by: str = Field(index=True)  # identity_address of room creator
     created_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
     updated_at: datetime = Field(default_factory=lambda: datetime.now(UTC))

--- a/backend/models.py
+++ b/backend/models.py
@@ -1,6 +1,8 @@
 import secrets
 from datetime import UTC, datetime, timedelta
+from enum import StrEnum
 
+from sqlalchemy import Column, ForeignKey, Integer, UniqueConstraint
 from sqlmodel import Field, Relationship, SQLModel
 
 
@@ -33,6 +35,70 @@ class Message(SQLModel, table=True):
     sender_address: str = Field(index=True)
     content: str
     created_at: datetime = Field(default_factory=lambda: datetime.now(UTC), index=True)
+
+
+class RsvpStatus(StrEnum):
+    """Attendance state a member can advertise for a scheduled RoomEvent."""
+
+    present = "present"
+    absent = "absent"
+    maybe = "maybe"
+
+
+class RoomEvent(SQLModel, table=True):
+    """A single scheduled gathering attached to a Room.
+
+    Issue #62 only requires one event per room, so `room_id` is unique.
+    Lifting that constraint later is a non-breaking change.
+    """
+
+    id: int | None = Field(default=None, primary_key=True)
+    room_id: int = Field(
+        sa_column=Column(
+            "room_id",
+            Integer,
+            ForeignKey("room.id", ondelete="CASCADE"),
+            unique=True,
+            index=True,
+            nullable=False,
+        ),
+    )
+    starts_at: datetime = Field(index=True)
+    created_by: str = Field(index=True)  # identity_address of room creator
+    created_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+    updated_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+
+
+class RoomEventRsvp(SQLModel, table=True):
+    """A member's attendance declaration for a RoomEvent.
+
+    A given user can hold at most one RSVP per event (enforced by the
+    composite unique constraint), updated through upsert semantics.
+    """
+
+    id: int | None = Field(default=None, primary_key=True)
+    event_id: int = Field(
+        sa_column=Column(
+            "event_id",
+            Integer,
+            ForeignKey("roomevent.id", ondelete="CASCADE"),
+            index=True,
+            nullable=False,
+        ),
+    )
+    user_id: int = Field(
+        sa_column=Column(
+            "user_id",
+            Integer,
+            ForeignKey("user.id", ondelete="CASCADE"),
+            index=True,
+            nullable=False,
+        ),
+    )
+    status: RsvpStatus
+    updated_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+
+    __table_args__ = (UniqueConstraint("event_id", "user_id"),)
 
 
 class Game(SQLModel, table=True):

--- a/backend/tests/test_room_events.py
+++ b/backend/tests/test_room_events.py
@@ -65,6 +65,14 @@ def _future_iso(minutes: int) -> str:
     return (datetime.now(UTC) + timedelta(minutes=minutes)).isoformat()
 
 
+def _event_body(start_minutes: int, duration_minutes: int = 120) -> dict[str, str]:
+    """Standard PUT /event body with sensible defaults."""
+    return {
+        "starts_at": _future_iso(start_minutes),
+        "ends_at": _future_iso(start_minutes + duration_minutes),
+    }
+
+
 # ---------- PUT /rooms/{name}/event ----------
 
 
@@ -73,7 +81,7 @@ def test_creator_can_schedule_event(client: TestClient, session: Session):
 
     res = client.put(
         "/rooms/lobby-1/event",
-        json={"starts_at": _future_iso(30)},
+        json=_event_body(30),
         headers=_auth_headers("0xCreator"),
     )
     assert res.status_code == 200
@@ -91,7 +99,7 @@ def test_non_creator_cannot_schedule_event(client: TestClient, session: Session)
 
     res = client.put(
         "/rooms/lobby-1/event",
-        json={"starts_at": _future_iso(30)},
+        json=_event_body(30),
         headers=_auth_headers("0xMember"),
     )
     assert res.status_code == 403
@@ -103,7 +111,7 @@ def test_outsider_cannot_schedule_event(client: TestClient, session: Session):
     # Outsider isn't even in the user table; treat like an unknown JWT subject.
     res = client.put(
         "/rooms/lobby-1/event",
-        json={"starts_at": _future_iso(30)},
+        json=_event_body(30),
         headers=_auth_headers("0xOutsider"),
     )
     assert res.status_code == 403
@@ -112,33 +120,71 @@ def test_outsider_cannot_schedule_event(client: TestClient, session: Session):
 def test_schedule_event_rejects_past_start(client: TestClient, session: Session):
     _seed_room(session, "lobby-1", ["0xCreator"])
 
-    past = (datetime.now(UTC) - timedelta(minutes=5)).isoformat()
+    body = {
+        "starts_at": (datetime.now(UTC) - timedelta(minutes=5)).isoformat(),
+        "ends_at": _future_iso(60),
+    }
     res = client.put(
         "/rooms/lobby-1/event",
-        json={"starts_at": past},
+        json=body,
         headers=_auth_headers("0xCreator"),
     )
     assert res.status_code == 400
     assert "future" in res.json()["detail"]
 
 
-def test_schedule_event_rejects_after_room_expiry(client: TestClient, session: Session):
-    _seed_room(session, "lobby-1", ["0xCreator"], expires_in_minutes=10)
+def test_schedule_event_extends_room_expiry_past_event_end(
+    client: TestClient, session: Session
+):
+    """An event scheduled past the current room.expires_at pushes the room's
+    expiry forward (with a grace period) so the room stays alive for the
+    whole session.
+    """
+    room = _seed_room(session, "lobby-1", ["0xCreator"], expires_in_minutes=10)
+    original_expiry = room.expires_at
 
-    # 30 minutes ahead, but room only lives for 10.
+    # Event ends 30 + 120 = 150 min from now, well past the 10-minute room.
     res = client.put(
         "/rooms/lobby-1/event",
-        json={"starts_at": _future_iso(30)},
+        json=_event_body(30),
+        headers=_auth_headers("0xCreator"),
+    )
+    assert res.status_code == 200
+
+    session.refresh(room)
+    new_expiry = room.expires_at
+    if new_expiry.tzinfo is None:
+        new_expiry = new_expiry.replace(tzinfo=UTC)
+    if original_expiry.tzinfo is None:
+        original_expiry = original_expiry.replace(tzinfo=UTC)
+    assert new_expiry > original_expiry
+    # Should be at least ends_at (start + 120 min).
+    ends_at = datetime.now(UTC) + timedelta(minutes=30 + 120)
+    assert new_expiry >= ends_at
+
+
+def test_schedule_event_rejects_ends_before_starts(
+    client: TestClient, session: Session
+):
+    _seed_room(session, "lobby-1", ["0xCreator"])
+
+    body = {
+        "starts_at": _future_iso(60),
+        "ends_at": _future_iso(30),  # before start
+    }
+    res = client.put(
+        "/rooms/lobby-1/event",
+        json=body,
         headers=_auth_headers("0xCreator"),
     )
     assert res.status_code == 400
-    assert "expires" in res.json()["detail"]
+    assert "ends_at" in res.json()["detail"]
 
 
 def test_schedule_event_for_missing_room_returns_404(client: TestClient):
     res = client.put(
         "/rooms/no-such-room/event",
-        json={"starts_at": _future_iso(30)},
+        json=_event_body(30),
         headers=_auth_headers("0xCreator"),
     )
     assert res.status_code == 404
@@ -149,7 +195,7 @@ def test_schedule_event_is_idempotent_upsert(client: TestClient, session: Sessio
 
     res = client.put(
         "/rooms/lobby-1/event",
-        json={"starts_at": _future_iso(30)},
+        json=_event_body(30),
         headers=_auth_headers("0xCreator"),
     )
     assert res.status_code == 200
@@ -157,7 +203,7 @@ def test_schedule_event_is_idempotent_upsert(client: TestClient, session: Sessio
 
     res = client.put(
         "/rooms/lobby-1/event",
-        json={"starts_at": _future_iso(45)},
+        json=_event_body(45),
         headers=_auth_headers("0xCreator"),
     )
     assert res.status_code == 200
@@ -176,7 +222,7 @@ def test_schedule_event_creator_match_is_case_insensitive(
     _seed_room(session, "lobby-1", ["0xAbC123"])
     res = client.put(
         "/rooms/lobby-1/event",
-        json={"starts_at": _future_iso(30)},
+        json=_event_body(30),
         headers=_auth_headers("0xabc123"),
     )
     assert res.status_code == 200
@@ -194,10 +240,9 @@ def test_get_event_returns_404_when_unscheduled(client: TestClient, session: Ses
 def test_get_event_is_public_and_includes_rsvps(client: TestClient, session: Session):
     _seed_room(session, "lobby-1", ["0xCreator", "0xMember"])
 
-    starts_at = _future_iso(30)
     client.put(
         "/rooms/lobby-1/event",
-        json={"starts_at": starts_at},
+        json=_event_body(30),
         headers=_auth_headers("0xCreator"),
     )
     client.put(
@@ -222,7 +267,7 @@ def test_get_room_includes_event_field(client: TestClient, session: Session):
 
     client.put(
         "/rooms/lobby-1/event",
-        json={"starts_at": _future_iso(30)},
+        json=_event_body(30),
         headers=_auth_headers("0xCreator"),
     )
     res = client.get("/rooms/lobby-1")
@@ -241,7 +286,7 @@ def test_member_can_set_each_rsvp_status(
     _seed_room(session, "lobby-1", ["0xCreator", "0xMember"])
     client.put(
         "/rooms/lobby-1/event",
-        json={"starts_at": _future_iso(30)},
+        json=_event_body(30),
         headers=_auth_headers("0xCreator"),
     )
 
@@ -258,7 +303,7 @@ def test_rsvp_overwrites_previous_status(client: TestClient, session: Session):
     _seed_room(session, "lobby-1", ["0xCreator", "0xMember"])
     client.put(
         "/rooms/lobby-1/event",
-        json={"starts_at": _future_iso(30)},
+        json=_event_body(30),
         headers=_auth_headers("0xCreator"),
     )
 
@@ -275,7 +320,7 @@ def test_outsider_cannot_rsvp(client: TestClient, session: Session):
     _seed_room(session, "lobby-1", ["0xCreator"])
     client.put(
         "/rooms/lobby-1/event",
-        json={"starts_at": _future_iso(30)},
+        json=_event_body(30),
         headers=_auth_headers("0xCreator"),
     )
 
@@ -304,7 +349,7 @@ def test_rsvp_rejects_invalid_status(client: TestClient, session: Session):
     _seed_room(session, "lobby-1", ["0xCreator"])
     client.put(
         "/rooms/lobby-1/event",
-        json={"starts_at": _future_iso(30)},
+        json=_event_body(30),
         headers=_auth_headers("0xCreator"),
     )
     res = client.put(
@@ -324,7 +369,7 @@ def test_creator_can_cancel_event_and_rsvps_are_cleared(
     _seed_room(session, "lobby-1", ["0xCreator", "0xMember"])
     client.put(
         "/rooms/lobby-1/event",
-        json={"starts_at": _future_iso(30)},
+        json=_event_body(30),
         headers=_auth_headers("0xCreator"),
     )
     client.put(
@@ -345,7 +390,7 @@ def test_non_creator_cannot_cancel_event(client: TestClient, session: Session):
     _seed_room(session, "lobby-1", ["0xCreator", "0xMember"])
     client.put(
         "/rooms/lobby-1/event",
-        json={"starts_at": _future_iso(30)},
+        json=_event_body(30),
         headers=_auth_headers("0xCreator"),
     )
 
@@ -366,7 +411,7 @@ def test_leave_room_removes_users_rsvp(client: TestClient, session: Session):
     _seed_room(session, "lobby-1", ["0xCreator", "0xMember"])
     client.put(
         "/rooms/lobby-1/event",
-        json={"starts_at": _future_iso(30)},
+        json=_event_body(30),
         headers=_auth_headers("0xCreator"),
     )
     client.put(
@@ -393,7 +438,7 @@ def test_expired_room_is_pruned_with_event_and_rsvps(
     _seed_room(session, "lobby-1", ["0xCreator", "0xMember"], expires_in_minutes=60)
     client.put(
         "/rooms/lobby-1/event",
-        json={"starts_at": _future_iso(30)},
+        json=_event_body(30),
         headers=_auth_headers("0xCreator"),
     )
     client.put(
@@ -442,7 +487,7 @@ def test_schedule_event_broadcasts_event_update(client: TestClient, session: Ses
 
         client.put(
             "/rooms/lobby-1/event",
-            json={"starts_at": _future_iso(30)},
+            json=_event_body(30),
             headers=_auth_headers("0xCreator"),
         )
 
@@ -457,7 +502,7 @@ def test_rsvp_update_broadcast(client: TestClient, session: Session):
     _seed_room(session, "lobby-1", ["0xCreator", "0xMember"])
     client.put(
         "/rooms/lobby-1/event",
-        json={"starts_at": _future_iso(30)},
+        json=_event_body(30),
         headers=_auth_headers("0xCreator"),
     )
     creator_t = _mint_token("0xCreator")
@@ -487,7 +532,7 @@ def test_leave_with_rsvp_broadcasts_event_update(client: TestClient, session: Se
     _seed_room(session, "lobby-1", ["0xCreator", "0xMember"])
     client.put(
         "/rooms/lobby-1/event",
-        json={"starts_at": _future_iso(30)},
+        json=_event_body(30),
         headers=_auth_headers("0xCreator"),
     )
     client.put(
@@ -511,7 +556,7 @@ def test_cancel_event_broadcasts_null_event(client: TestClient, session: Session
     _seed_room(session, "lobby-1", ["0xCreator", "0xMember"])
     client.put(
         "/rooms/lobby-1/event",
-        json={"starts_at": _future_iso(30)},
+        json=_event_body(30),
         headers=_auth_headers("0xCreator"),
     )
 
@@ -566,7 +611,7 @@ def test_event_payload_shape(client: TestClient, session: Session):
     _seed_room(session, "lobby-1", ["0xCreator", "0xMember"])
     client.put(
         "/rooms/lobby-1/event",
-        json={"starts_at": _future_iso(30)},
+        json=_event_body(30),
         headers=_auth_headers("0xCreator"),
     )
     client.put(
@@ -578,6 +623,7 @@ def test_event_payload_shape(client: TestClient, session: Session):
     body = client.get("/rooms/lobby-1/event").json()
     assert set(body.keys()) == {
         "starts_at",
+        "ends_at",
         "created_by",
         "created_at",
         "updated_at",
@@ -592,7 +638,7 @@ def test_event_payload_shape(client: TestClient, session: Session):
         ws.receive_json()  # history
         client.put(
             "/rooms/lobby-1/event",
-            json={"starts_at": _future_iso(45)},
+            json=_event_body(45),
             headers=_auth_headers("0xCreator"),
         )
         frame = ws.receive_json()
@@ -600,6 +646,7 @@ def test_event_payload_shape(client: TestClient, session: Session):
         assert set(frame.keys()) == {"type", "event"}
         assert set(frame["event"].keys()) == {
             "starts_at",
+            "ends_at",
             "created_by",
             "created_at",
             "updated_at",
@@ -613,7 +660,7 @@ def test_rest_and_ws_event_payloads_match(client: TestClient, session: Session):
     _seed_room(session, "lobby-1", ["0xCreator", "0xMember"])
     client.put(
         "/rooms/lobby-1/event",
-        json={"starts_at": _future_iso(30)},
+        json=_event_body(30),
         headers=_auth_headers("0xCreator"),
     )
 
@@ -628,7 +675,7 @@ def test_rest_and_ws_event_payloads_match(client: TestClient, session: Session):
         ws.receive_json()  # the rsvp_update frame, drop it
         client.put(
             "/rooms/lobby-1/event",
-            json={"starts_at": _future_iso(45)},
+            json=_event_body(45),
             headers=_auth_headers("0xCreator"),
         )
         ws_frame = ws.receive_json()

--- a/backend/tests/test_room_events.py
+++ b/backend/tests/test_room_events.py
@@ -1,0 +1,640 @@
+"""Tests for the scheduled-event + RSVP feature on rooms (issue #62)."""
+
+import json
+import os
+from datetime import UTC, datetime, timedelta
+
+import jwt
+import pytest
+from fastapi.testclient import TestClient
+from sqlmodel import Session, select
+
+from models import Room, RoomEvent, RoomEventRsvp, RsvpStatus, User
+
+# ---------- helpers ----------
+
+
+def _mint_token(address: str) -> str:
+    secret = os.environ["JWT_SECRET"]
+    payload = {
+        "sub": address,
+        "username": "tester",
+        "iat": datetime.now(UTC),
+        "exp": datetime.now(UTC) + timedelta(minutes=5),
+        "iss": "playlink-auth",
+    }
+    return jwt.encode(payload, secret, algorithm="HS256")
+
+
+def _auth_headers(address: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {_mint_token(address)}"}
+
+
+def _seed_room(
+    session: Session,
+    room_name: str,
+    members: list[str],
+    *,
+    expires_in_minutes: int = 60,
+) -> Room:
+    """Create users + a room with `members[0]` as creator and everyone joined."""
+    user_objs: list[User] = []
+    for addr in members:
+        u = User(identity_address=addr)
+        session.add(u)
+        user_objs.append(u)
+    session.commit()
+    for u in user_objs:
+        session.refresh(u)
+
+    room = Room(
+        name=room_name,
+        game="Quake III Arena",
+        players_max=4,
+        created_by=members[0],
+        expires_at=datetime.now(UTC) + timedelta(minutes=expires_in_minutes),
+    )
+    room.members.extend(user_objs)
+    session.add(room)
+    session.commit()
+    session.refresh(room)
+    return room
+
+
+def _future_iso(minutes: int) -> str:
+    return (datetime.now(UTC) + timedelta(minutes=minutes)).isoformat()
+
+
+# ---------- PUT /rooms/{name}/event ----------
+
+
+def test_creator_can_schedule_event(client: TestClient, session: Session):
+    _seed_room(session, "lobby-1", ["0xCreator", "0xMember"])
+
+    res = client.put(
+        "/rooms/lobby-1/event",
+        json={"starts_at": _future_iso(30)},
+        headers=_auth_headers("0xCreator"),
+    )
+    assert res.status_code == 200
+    body = res.json()
+    assert "starts_at" in body
+    assert body["created_by"] == "0xCreator"
+    assert body["rsvps"] == []
+
+    persisted = session.exec(select(RoomEvent)).all()
+    assert len(persisted) == 1
+
+
+def test_non_creator_cannot_schedule_event(client: TestClient, session: Session):
+    _seed_room(session, "lobby-1", ["0xCreator", "0xMember"])
+
+    res = client.put(
+        "/rooms/lobby-1/event",
+        json={"starts_at": _future_iso(30)},
+        headers=_auth_headers("0xMember"),
+    )
+    assert res.status_code == 403
+    assert "creator" in res.json()["detail"].lower()
+
+
+def test_outsider_cannot_schedule_event(client: TestClient, session: Session):
+    _seed_room(session, "lobby-1", ["0xCreator"])
+    # Outsider isn't even in the user table; treat like an unknown JWT subject.
+    res = client.put(
+        "/rooms/lobby-1/event",
+        json={"starts_at": _future_iso(30)},
+        headers=_auth_headers("0xOutsider"),
+    )
+    assert res.status_code == 403
+
+
+def test_schedule_event_rejects_past_start(client: TestClient, session: Session):
+    _seed_room(session, "lobby-1", ["0xCreator"])
+
+    past = (datetime.now(UTC) - timedelta(minutes=5)).isoformat()
+    res = client.put(
+        "/rooms/lobby-1/event",
+        json={"starts_at": past},
+        headers=_auth_headers("0xCreator"),
+    )
+    assert res.status_code == 400
+    assert "future" in res.json()["detail"]
+
+
+def test_schedule_event_rejects_after_room_expiry(client: TestClient, session: Session):
+    _seed_room(session, "lobby-1", ["0xCreator"], expires_in_minutes=10)
+
+    # 30 minutes ahead, but room only lives for 10.
+    res = client.put(
+        "/rooms/lobby-1/event",
+        json={"starts_at": _future_iso(30)},
+        headers=_auth_headers("0xCreator"),
+    )
+    assert res.status_code == 400
+    assert "expires" in res.json()["detail"]
+
+
+def test_schedule_event_for_missing_room_returns_404(client: TestClient):
+    res = client.put(
+        "/rooms/no-such-room/event",
+        json={"starts_at": _future_iso(30)},
+        headers=_auth_headers("0xCreator"),
+    )
+    assert res.status_code == 404
+
+
+def test_schedule_event_is_idempotent_upsert(client: TestClient, session: Session):
+    _seed_room(session, "lobby-1", ["0xCreator"])
+
+    res = client.put(
+        "/rooms/lobby-1/event",
+        json={"starts_at": _future_iso(30)},
+        headers=_auth_headers("0xCreator"),
+    )
+    assert res.status_code == 200
+    first = res.json()
+
+    res = client.put(
+        "/rooms/lobby-1/event",
+        json={"starts_at": _future_iso(45)},
+        headers=_auth_headers("0xCreator"),
+    )
+    assert res.status_code == 200
+    second = res.json()
+
+    assert second["starts_at"] != first["starts_at"]
+    # Still exactly one event row (no duplicate inserts).
+    assert len(session.exec(select(RoomEvent)).all()) == 1
+
+
+def test_schedule_event_creator_match_is_case_insensitive(
+    client: TestClient, session: Session
+):
+    # Room creator stored mixed-case; caller's JWT carries the same address
+    # in lower case (e.g. coming from a different normalization path).
+    _seed_room(session, "lobby-1", ["0xAbC123"])
+    res = client.put(
+        "/rooms/lobby-1/event",
+        json={"starts_at": _future_iso(30)},
+        headers=_auth_headers("0xabc123"),
+    )
+    assert res.status_code == 200
+
+
+# ---------- GET /rooms/{name}/event ----------
+
+
+def test_get_event_returns_404_when_unscheduled(client: TestClient, session: Session):
+    _seed_room(session, "lobby-1", ["0xCreator"])
+    res = client.get("/rooms/lobby-1/event")
+    assert res.status_code == 404
+
+
+def test_get_event_is_public_and_includes_rsvps(client: TestClient, session: Session):
+    _seed_room(session, "lobby-1", ["0xCreator", "0xMember"])
+
+    starts_at = _future_iso(30)
+    client.put(
+        "/rooms/lobby-1/event",
+        json={"starts_at": starts_at},
+        headers=_auth_headers("0xCreator"),
+    )
+    client.put(
+        "/rooms/lobby-1/event/rsvp",
+        json={"status": "present"},
+        headers=_auth_headers("0xMember"),
+    )
+
+    res = client.get("/rooms/lobby-1/event")  # no auth header on purpose
+    assert res.status_code == 200
+    body = res.json()
+    assert body["created_by"] == "0xCreator"
+    assert {r["address"]: r["status"] for r in body["rsvps"]} == {"0xMember": "present"}
+
+
+def test_get_room_includes_event_field(client: TestClient, session: Session):
+    _seed_room(session, "lobby-1", ["0xCreator"])
+
+    res = client.get("/rooms/lobby-1")
+    assert res.status_code == 200
+    assert res.json()["event"] is None
+
+    client.put(
+        "/rooms/lobby-1/event",
+        json={"starts_at": _future_iso(30)},
+        headers=_auth_headers("0xCreator"),
+    )
+    res = client.get("/rooms/lobby-1")
+    assert res.status_code == 200
+    assert res.json()["event"] is not None
+    assert res.json()["event"]["created_by"] == "0xCreator"
+
+
+# ---------- PUT /rooms/{name}/event/rsvp ----------
+
+
+@pytest.mark.parametrize("status", ["present", "absent", "maybe"])
+def test_member_can_set_each_rsvp_status(
+    client: TestClient, session: Session, status: str
+):
+    _seed_room(session, "lobby-1", ["0xCreator", "0xMember"])
+    client.put(
+        "/rooms/lobby-1/event",
+        json={"starts_at": _future_iso(30)},
+        headers=_auth_headers("0xCreator"),
+    )
+
+    res = client.put(
+        "/rooms/lobby-1/event/rsvp",
+        json={"status": status},
+        headers=_auth_headers("0xMember"),
+    )
+    assert res.status_code == 200
+    assert res.json()["status"] == status
+
+
+def test_rsvp_overwrites_previous_status(client: TestClient, session: Session):
+    _seed_room(session, "lobby-1", ["0xCreator", "0xMember"])
+    client.put(
+        "/rooms/lobby-1/event",
+        json={"starts_at": _future_iso(30)},
+        headers=_auth_headers("0xCreator"),
+    )
+
+    h = _auth_headers("0xMember")
+    client.put("/rooms/lobby-1/event/rsvp", json={"status": "present"}, headers=h)
+    client.put("/rooms/lobby-1/event/rsvp", json={"status": "maybe"}, headers=h)
+
+    rows = session.exec(select(RoomEventRsvp)).all()
+    assert len(rows) == 1
+    assert rows[0].status == RsvpStatus.maybe
+
+
+def test_outsider_cannot_rsvp(client: TestClient, session: Session):
+    _seed_room(session, "lobby-1", ["0xCreator"])
+    client.put(
+        "/rooms/lobby-1/event",
+        json={"starts_at": _future_iso(30)},
+        headers=_auth_headers("0xCreator"),
+    )
+
+    # Outsider with a valid token but no row in user table.
+    res = client.put(
+        "/rooms/lobby-1/event/rsvp",
+        json={"status": "present"},
+        headers=_auth_headers("0xOutsider"),
+    )
+    # User not found → 404 (the endpoint resolves the user before membership).
+    # We accept either 403 or 404 depending on how the principal is missing.
+    assert res.status_code in (403, 404)
+
+
+def test_rsvp_requires_existing_event(client: TestClient, session: Session):
+    _seed_room(session, "lobby-1", ["0xCreator"])
+    res = client.put(
+        "/rooms/lobby-1/event/rsvp",
+        json={"status": "present"},
+        headers=_auth_headers("0xCreator"),
+    )
+    assert res.status_code == 404
+
+
+def test_rsvp_rejects_invalid_status(client: TestClient, session: Session):
+    _seed_room(session, "lobby-1", ["0xCreator"])
+    client.put(
+        "/rooms/lobby-1/event",
+        json={"starts_at": _future_iso(30)},
+        headers=_auth_headers("0xCreator"),
+    )
+    res = client.put(
+        "/rooms/lobby-1/event/rsvp",
+        json={"status": "nope"},
+        headers=_auth_headers("0xCreator"),
+    )
+    assert res.status_code == 422
+
+
+# ---------- DELETE /rooms/{name}/event ----------
+
+
+def test_creator_can_cancel_event_and_rsvps_are_cleared(
+    client: TestClient, session: Session
+):
+    _seed_room(session, "lobby-1", ["0xCreator", "0xMember"])
+    client.put(
+        "/rooms/lobby-1/event",
+        json={"starts_at": _future_iso(30)},
+        headers=_auth_headers("0xCreator"),
+    )
+    client.put(
+        "/rooms/lobby-1/event/rsvp",
+        json={"status": "present"},
+        headers=_auth_headers("0xMember"),
+    )
+
+    res = client.delete("/rooms/lobby-1/event", headers=_auth_headers("0xCreator"))
+    assert res.status_code == 200
+
+    assert session.exec(select(RoomEvent)).all() == []
+    assert session.exec(select(RoomEventRsvp)).all() == []
+    assert client.get("/rooms/lobby-1/event").status_code == 404
+
+
+def test_non_creator_cannot_cancel_event(client: TestClient, session: Session):
+    _seed_room(session, "lobby-1", ["0xCreator", "0xMember"])
+    client.put(
+        "/rooms/lobby-1/event",
+        json={"starts_at": _future_iso(30)},
+        headers=_auth_headers("0xCreator"),
+    )
+
+    res = client.delete("/rooms/lobby-1/event", headers=_auth_headers("0xMember"))
+    assert res.status_code == 403
+
+
+def test_cancel_event_404_when_none(client: TestClient, session: Session):
+    _seed_room(session, "lobby-1", ["0xCreator"])
+    res = client.delete("/rooms/lobby-1/event", headers=_auth_headers("0xCreator"))
+    assert res.status_code == 404
+
+
+# ---------- leave_room interaction ----------
+
+
+def test_leave_room_removes_users_rsvp(client: TestClient, session: Session):
+    _seed_room(session, "lobby-1", ["0xCreator", "0xMember"])
+    client.put(
+        "/rooms/lobby-1/event",
+        json={"starts_at": _future_iso(30)},
+        headers=_auth_headers("0xCreator"),
+    )
+    client.put(
+        "/rooms/lobby-1/event/rsvp",
+        json={"status": "present"},
+        headers=_auth_headers("0xMember"),
+    )
+
+    res = client.post("/rooms/lobby-1/leave", headers=_auth_headers("0xMember"))
+    assert res.status_code == 200
+
+    rsvp_rows = session.exec(select(RoomEventRsvp)).all()
+    assert rsvp_rows == []
+    body = client.get("/rooms/lobby-1/event").json()
+    assert body["rsvps"] == []
+
+
+# ---------- prune of expired rooms cleans events & rsvps ----------
+
+
+def test_expired_room_is_pruned_with_event_and_rsvps(
+    client: TestClient, session: Session
+):
+    _seed_room(session, "lobby-1", ["0xCreator", "0xMember"], expires_in_minutes=60)
+    client.put(
+        "/rooms/lobby-1/event",
+        json={"starts_at": _future_iso(30)},
+        headers=_auth_headers("0xCreator"),
+    )
+    client.put(
+        "/rooms/lobby-1/event/rsvp",
+        json={"status": "present"},
+        headers=_auth_headers("0xMember"),
+    )
+
+    # Force the room to expire by rewriting its expires_at directly.
+    room = session.exec(select(Room).where(Room.name == "lobby-1")).first()
+    assert room is not None
+    room.expires_at = datetime.now(UTC) - timedelta(seconds=1)
+    session.add(room)
+    session.commit()
+
+    # GET /rooms triggers get_rooms_payload, which prunes expired rooms.
+    res = client.get("/rooms")
+    assert res.status_code == 200
+
+    # Pruning fires on the next mutation that calls get_rooms_payload, so
+    # nudge it via the rooms-list WebSocket which sends the freshly built
+    # payload immediately on connect.
+    with client.websocket_connect("/ws/rooms") as ws:
+        ws.receive_text()  # discard the initial snapshot
+
+    # Now everything tied to the expired room should be gone.
+    assert session.exec(select(Room)).all() == []
+    assert session.exec(select(RoomEvent)).all() == []
+    assert session.exec(select(RoomEventRsvp)).all() == []
+
+
+# ---------- realtime broadcast over the chat WebSocket ----------
+
+
+def test_schedule_event_broadcasts_event_update(client: TestClient, session: Session):
+    _seed_room(session, "lobby-1", ["0xCreator", "0xMember"])
+    creator_t = _mint_token("0xCreator")
+    member_t = _mint_token("0xMember")
+
+    with (
+        client.websocket_connect(f"/ws/rooms/lobby-1/chat?token={creator_t}") as ws_a,
+        client.websocket_connect(f"/ws/rooms/lobby-1/chat?token={member_t}") as ws_b,
+    ):
+        ws_a.receive_json()  # history
+        ws_b.receive_json()
+
+        client.put(
+            "/rooms/lobby-1/event",
+            json={"starts_at": _future_iso(30)},
+            headers=_auth_headers("0xCreator"),
+        )
+
+        for ws in (ws_a, ws_b):
+            frame = ws.receive_json()
+            assert frame["type"] == "event_update"
+            assert frame["event"]["created_by"] == "0xCreator"
+            assert frame["event"]["rsvps"] == []
+
+
+def test_rsvp_update_broadcast(client: TestClient, session: Session):
+    _seed_room(session, "lobby-1", ["0xCreator", "0xMember"])
+    client.put(
+        "/rooms/lobby-1/event",
+        json={"starts_at": _future_iso(30)},
+        headers=_auth_headers("0xCreator"),
+    )
+    creator_t = _mint_token("0xCreator")
+    member_t = _mint_token("0xMember")
+
+    with (
+        client.websocket_connect(f"/ws/rooms/lobby-1/chat?token={creator_t}") as ws_a,
+        client.websocket_connect(f"/ws/rooms/lobby-1/chat?token={member_t}") as ws_b,
+    ):
+        ws_a.receive_json()
+        ws_b.receive_json()
+
+        client.put(
+            "/rooms/lobby-1/event/rsvp",
+            json={"status": "maybe"},
+            headers=_auth_headers("0xMember"),
+        )
+
+        for ws in (ws_a, ws_b):
+            frame = ws.receive_json()
+            assert frame["type"] == "rsvp_update"
+            assert frame["rsvp"]["address"] == "0xMember"
+            assert frame["rsvp"]["status"] == "maybe"
+
+
+def test_leave_with_rsvp_broadcasts_event_update(client: TestClient, session: Session):
+    _seed_room(session, "lobby-1", ["0xCreator", "0xMember"])
+    client.put(
+        "/rooms/lobby-1/event",
+        json={"starts_at": _future_iso(30)},
+        headers=_auth_headers("0xCreator"),
+    )
+    client.put(
+        "/rooms/lobby-1/event/rsvp",
+        json={"status": "present"},
+        headers=_auth_headers("0xMember"),
+    )
+
+    creator_t = _mint_token("0xCreator")
+    with client.websocket_connect(f"/ws/rooms/lobby-1/chat?token={creator_t}") as ws_a:
+        ws_a.receive_json()  # history
+
+        client.post("/rooms/lobby-1/leave", headers=_auth_headers("0xMember"))
+
+        frame = ws_a.receive_json()
+        assert frame["type"] == "event_update"
+        assert frame["event"]["rsvps"] == []
+
+
+def test_cancel_event_broadcasts_null_event(client: TestClient, session: Session):
+    _seed_room(session, "lobby-1", ["0xCreator", "0xMember"])
+    client.put(
+        "/rooms/lobby-1/event",
+        json={"starts_at": _future_iso(30)},
+        headers=_auth_headers("0xCreator"),
+    )
+
+    creator_t = _mint_token("0xCreator")
+    member_t = _mint_token("0xMember")
+    with (
+        client.websocket_connect(f"/ws/rooms/lobby-1/chat?token={creator_t}") as ws_a,
+        client.websocket_connect(f"/ws/rooms/lobby-1/chat?token={member_t}") as ws_b,
+    ):
+        ws_a.receive_json()
+        ws_b.receive_json()
+
+        client.delete("/rooms/lobby-1/event", headers=_auth_headers("0xCreator"))
+
+        for ws in (ws_a, ws_b):
+            frame = ws.receive_json()
+            assert frame["type"] == "event_update"
+            assert frame["event"] is None
+
+
+# ---------- regression: chat frames stay parseable ----------
+
+
+def test_chat_history_and_message_frames_unchanged(
+    client: TestClient, session: Session
+):
+    _seed_room(session, "lobby-1", ["0xCreator"])
+    token = _mint_token("0xCreator")
+
+    with client.websocket_connect(f"/ws/rooms/lobby-1/chat?token={token}") as ws:
+        history = ws.receive_json()
+        assert history == {"type": "history", "messages": []}
+
+        ws.send_json({"content": "hi"})
+        msg = ws.receive_json()
+        # No new top-level keys leaked into existing frames.
+        assert set(msg.keys()) == {"type", "message"}
+        assert msg["type"] == "message"
+        assert set(msg["message"].keys()) == {
+            "id",
+            "sender_address",
+            "sender_username",
+            "content",
+            "created_at",
+        }
+
+
+# ---------- defence-in-depth: payload shape ----------
+
+
+def test_event_payload_shape(client: TestClient, session: Session):
+    _seed_room(session, "lobby-1", ["0xCreator", "0xMember"])
+    client.put(
+        "/rooms/lobby-1/event",
+        json={"starts_at": _future_iso(30)},
+        headers=_auth_headers("0xCreator"),
+    )
+    client.put(
+        "/rooms/lobby-1/event/rsvp",
+        json={"status": "present"},
+        headers=_auth_headers("0xMember"),
+    )
+
+    body = client.get("/rooms/lobby-1/event").json()
+    assert set(body.keys()) == {
+        "starts_at",
+        "created_by",
+        "created_at",
+        "updated_at",
+        "rsvps",
+    }
+    rsvp = body["rsvps"][0]
+    assert set(rsvp.keys()) == {"address", "username", "status", "updated_at"}
+
+    # Same shape over WS.
+    token = _mint_token("0xCreator")
+    with client.websocket_connect(f"/ws/rooms/lobby-1/chat?token={token}") as ws:
+        ws.receive_json()  # history
+        client.put(
+            "/rooms/lobby-1/event",
+            json={"starts_at": _future_iso(45)},
+            headers=_auth_headers("0xCreator"),
+        )
+        frame = ws.receive_json()
+        # Frame envelope plus the same event keys as REST.
+        assert set(frame.keys()) == {"type", "event"}
+        assert set(frame["event"].keys()) == {
+            "starts_at",
+            "created_by",
+            "created_at",
+            "updated_at",
+            "rsvps",
+        }
+
+
+# Sanity check: ensure JSON serialization works the same as REST when payload
+# is built off the same helper. This protects against silent drift.
+def test_rest_and_ws_event_payloads_match(client: TestClient, session: Session):
+    _seed_room(session, "lobby-1", ["0xCreator", "0xMember"])
+    client.put(
+        "/rooms/lobby-1/event",
+        json={"starts_at": _future_iso(30)},
+        headers=_auth_headers("0xCreator"),
+    )
+
+    token = _mint_token("0xCreator")
+    with client.websocket_connect(f"/ws/rooms/lobby-1/chat?token={token}") as ws:
+        ws.receive_json()  # history
+        client.put(
+            "/rooms/lobby-1/event/rsvp",
+            json={"status": "present"},
+            headers=_auth_headers("0xCreator"),
+        )
+        ws.receive_json()  # the rsvp_update frame, drop it
+        client.put(
+            "/rooms/lobby-1/event",
+            json={"starts_at": _future_iso(45)},
+            headers=_auth_headers("0xCreator"),
+        )
+        ws_frame = ws.receive_json()
+
+    rest_payload = client.get("/rooms/lobby-1/event").json()
+    # WS frame's `event` should match REST byte-for-byte (same helper).
+    assert json.dumps(ws_frame["event"], sort_keys=True) == json.dumps(
+        rest_payload, sort_keys=True
+    )

--- a/backend/tests/test_room_events.py
+++ b/backend/tests/test_room_events.py
@@ -528,6 +528,44 @@ def test_rsvp_update_broadcast(client: TestClient, session: Session):
             assert frame["rsvp"]["status"] == "maybe"
 
 
+def test_join_broadcasts_roster_update(client: TestClient, session: Session):
+    """A second member joining mid-session appears in the chat WS roster
+    of an already-connected member."""
+    _seed_room(session, "lobby-1", ["0xCreator"])
+    creator_t = _mint_token("0xCreator")
+
+    # Pre-create the joining user so the JWT subject resolves to a real user.
+    new_user = User(identity_address="0xJoiner")
+    session.add(new_user)
+    session.commit()
+
+    with client.websocket_connect(f"/ws/rooms/lobby-1/chat?token={creator_t}") as ws:
+        ws.receive_json()  # history
+
+        client.post("/rooms/lobby-1/join", headers=_auth_headers("0xJoiner"))
+
+        frame = ws.receive_json()
+        assert frame["type"] == "roster_update"
+        addrs = [m["address"] for m in frame["members"]]
+        assert "0xCreator" in addrs
+        assert "0xJoiner" in addrs
+
+
+def test_leave_broadcasts_roster_update(client: TestClient, session: Session):
+    _seed_room(session, "lobby-1", ["0xCreator", "0xMember"])
+    creator_t = _mint_token("0xCreator")
+
+    with client.websocket_connect(f"/ws/rooms/lobby-1/chat?token={creator_t}") as ws:
+        ws.receive_json()  # history
+
+        client.post("/rooms/lobby-1/leave", headers=_auth_headers("0xMember"))
+
+        frame = ws.receive_json()
+        assert frame["type"] == "roster_update"
+        addrs = [m["address"] for m in frame["members"]]
+        assert addrs == ["0xCreator"]
+
+
 def test_leave_with_rsvp_broadcasts_event_update(client: TestClient, session: Session):
     _seed_room(session, "lobby-1", ["0xCreator", "0xMember"])
     client.put(
@@ -547,9 +585,15 @@ def test_leave_with_rsvp_broadcasts_event_update(client: TestClient, session: Se
 
         client.post("/rooms/lobby-1/leave", headers=_auth_headers("0xMember"))
 
-        frame = ws_a.receive_json()
-        assert frame["type"] == "event_update"
-        assert frame["event"]["rsvps"] == []
+        # leave broadcasts roster_update first, then event_update because the
+        # member had an RSVP that needs clearing.
+        roster_frame = ws_a.receive_json()
+        assert roster_frame["type"] == "roster_update"
+        assert [m["address"] for m in roster_frame["members"]] == ["0xCreator"]
+
+        event_frame = ws_a.receive_json()
+        assert event_frame["type"] == "event_update"
+        assert event_frame["event"]["rsvps"] == []
 
 
 def test_cancel_event_broadcasts_null_event(client: TestClient, session: Session):

--- a/frontend/src/lib/chatStore.ts
+++ b/frontend/src/lib/chatStore.ts
@@ -23,6 +23,7 @@ export interface RsvpEntry {
 
 export interface RoomEventState {
 	starts_at: string;
+	ends_at: string;
 	created_by: string;
 	created_at: string;
 	updated_at: string;
@@ -87,6 +88,7 @@ function isRoomEventState(value: unknown): value is RoomEventState {
 	const e = value as Record<string, unknown>;
 	return (
 		typeof e.starts_at === 'string' &&
+		typeof e.ends_at === 'string' &&
 		typeof e.created_by === 'string' &&
 		typeof e.created_at === 'string' &&
 		typeof e.updated_at === 'string' &&

--- a/frontend/src/lib/chatStore.ts
+++ b/frontend/src/lib/chatStore.ts
@@ -2,6 +2,8 @@ import { browser } from '$app/environment';
 import { env } from '$env/dynamic/public';
 import { writable, type Readable } from 'svelte/store';
 
+// ---------- Public types ----------
+
 export interface ChatMessage {
 	id: number;
 	sender_address: string;
@@ -9,6 +11,25 @@ export interface ChatMessage {
 	content: string;
 	created_at: string;
 }
+
+export type RsvpStatus = 'present' | 'absent' | 'maybe';
+
+export interface RsvpEntry {
+	address: string;
+	username: string;
+	status: RsvpStatus;
+	updated_at: string;
+}
+
+export interface RoomEventState {
+	starts_at: string;
+	created_by: string;
+	created_at: string;
+	updated_at: string;
+	rsvps: RsvpEntry[];
+}
+
+// ---------- Frame types (private) ----------
 
 interface HistoryFrame {
 	type: 'history';
@@ -20,7 +41,19 @@ interface MessageFrame {
 	message: ChatMessage;
 }
 
-type ChatFrame = HistoryFrame | MessageFrame;
+interface EventUpdateFrame {
+	type: 'event_update';
+	event: RoomEventState | null;
+}
+
+interface RsvpUpdateFrame {
+	type: 'rsvp_update';
+	rsvp: RsvpEntry;
+}
+
+type ChatFrame = HistoryFrame | MessageFrame | EventUpdateFrame | RsvpUpdateFrame;
+
+// ---------- Frame validation ----------
 
 function isChatMessage(value: unknown): value is ChatMessage {
 	if (typeof value !== 'object' || value === null) return false;
@@ -31,6 +64,34 @@ function isChatMessage(value: unknown): value is ChatMessage {
 		typeof m.sender_username === 'string' &&
 		typeof m.content === 'string' &&
 		typeof m.created_at === 'string'
+	);
+}
+
+function isRsvpStatus(value: unknown): value is RsvpStatus {
+	return value === 'present' || value === 'absent' || value === 'maybe';
+}
+
+function isRsvpEntry(value: unknown): value is RsvpEntry {
+	if (typeof value !== 'object' || value === null) return false;
+	const r = value as Record<string, unknown>;
+	return (
+		typeof r.address === 'string' &&
+		typeof r.username === 'string' &&
+		isRsvpStatus(r.status) &&
+		typeof r.updated_at === 'string'
+	);
+}
+
+function isRoomEventState(value: unknown): value is RoomEventState {
+	if (typeof value !== 'object' || value === null) return false;
+	const e = value as Record<string, unknown>;
+	return (
+		typeof e.starts_at === 'string' &&
+		typeof e.created_by === 'string' &&
+		typeof e.created_at === 'string' &&
+		typeof e.updated_at === 'string' &&
+		Array.isArray(e.rsvps) &&
+		e.rsvps.every(isRsvpEntry)
 	);
 }
 
@@ -49,16 +110,41 @@ function parseFrame(raw: string): ChatFrame | null {
 	if (f.type === 'message' && isChatMessage(f.message)) {
 		return { type: 'message', message: f.message };
 	}
+	if (f.type === 'event_update' && (f.event === null || isRoomEventState(f.event))) {
+		return {
+			type: 'event_update',
+			event: f.event as RoomEventState | null
+		};
+	}
+	if (f.type === 'rsvp_update' && isRsvpEntry(f.rsvp)) {
+		return { type: 'rsvp_update', rsvp: f.rsvp };
+	}
 	return null;
 }
 
-export interface ChatStore extends Readable<ChatMessage[]> {
+// ---------- Store ----------
+
+export interface ChatStore {
+	/** Live chat history for the room. */
+	messages: Readable<ChatMessage[]>;
+	/** Current scheduled event (or null when none / not yet observed). */
+	event: Readable<RoomEventState | null>;
 	send(content: string): void;
 	destroy(): void;
 }
 
-export function createChatStore(roomName: string, token: string): ChatStore {
-	const { subscribe, set, update } = writable<ChatMessage[]>([]);
+export interface CreateChatStoreOptions {
+	/** Initial event state from SSR, if any. Avoids a flash of empty content. */
+	initialEvent?: RoomEventState | null;
+}
+
+export function createChatStore(
+	roomName: string,
+	token: string,
+	options: CreateChatStoreOptions = {}
+): ChatStore {
+	const messages = writable<ChatMessage[]>([]);
+	const event = writable<RoomEventState | null>(options.initialEvent ?? null);
 
 	let ws: WebSocket | null = null;
 	let reconnectTimeout: ReturnType<typeof setTimeout> | null = null;
@@ -66,6 +152,16 @@ export function createChatStore(roomName: string, token: string): ChatStore {
 	let isTornDown = false;
 	const baseDelayMs = 1000;
 	const maxDelayMs = 30000;
+
+	function applyRsvpUpdate(rsvp: RsvpEntry) {
+		event.update((current) => {
+			if (!current) return current;
+			const filtered = current.rsvps.filter(
+				(r) => r.address.toLowerCase() !== rsvp.address.toLowerCase()
+			);
+			return { ...current, rsvps: [...filtered, rsvp] };
+		});
+	}
 
 	function connect() {
 		const wsUrl = env.PUBLIC_WS_URL;
@@ -82,16 +178,25 @@ export function createChatStore(roomName: string, token: string): ChatStore {
 			reconnectAttempts = 0;
 		};
 
-		ws.onmessage = (event: MessageEvent<string>) => {
-			const frame = parseFrame(event.data);
+		ws.onmessage = (frameEvent: MessageEvent<string>) => {
+			const frame = parseFrame(frameEvent.data);
 			if (!frame) {
-				console.error('Bad chat frame', event.data);
+				console.error('Bad chat frame', frameEvent.data);
 				return;
 			}
-			if (frame.type === 'history') {
-				set(frame.messages);
-			} else {
-				update((msgs) => [...msgs, frame.message]);
+			switch (frame.type) {
+				case 'history':
+					messages.set(frame.messages);
+					break;
+				case 'message':
+					messages.update((msgs) => [...msgs, frame.message]);
+					break;
+				case 'event_update':
+					event.set(frame.event);
+					break;
+				case 'rsvp_update':
+					applyRsvpUpdate(frame.rsvp);
+					break;
 			}
 		};
 
@@ -118,7 +223,8 @@ export function createChatStore(roomName: string, token: string): ChatStore {
 	}
 
 	return {
-		subscribe,
+		messages: { subscribe: messages.subscribe },
+		event: { subscribe: event.subscribe },
 		send(content: string) {
 			const trimmed = content.trim();
 			if (!trimmed || !ws || ws.readyState !== WebSocket.OPEN) return;

--- a/frontend/src/lib/chatStore.ts
+++ b/frontend/src/lib/chatStore.ts
@@ -12,6 +12,11 @@ export interface ChatMessage {
 	created_at: string;
 }
 
+export interface RoomMember {
+	address: string;
+	username: string;
+}
+
 export type RsvpStatus = 'present' | 'absent' | 'maybe';
 
 export interface RsvpEntry {
@@ -52,7 +57,17 @@ interface RsvpUpdateFrame {
 	rsvp: RsvpEntry;
 }
 
-type ChatFrame = HistoryFrame | MessageFrame | EventUpdateFrame | RsvpUpdateFrame;
+interface RosterUpdateFrame {
+	type: 'roster_update';
+	members: RoomMember[];
+}
+
+type ChatFrame =
+	| HistoryFrame
+	| MessageFrame
+	| EventUpdateFrame
+	| RsvpUpdateFrame
+	| RosterUpdateFrame;
 
 // ---------- Frame validation ----------
 
@@ -66,6 +81,12 @@ function isChatMessage(value: unknown): value is ChatMessage {
 		typeof m.content === 'string' &&
 		typeof m.created_at === 'string'
 	);
+}
+
+function isRoomMember(value: unknown): value is RoomMember {
+	if (typeof value !== 'object' || value === null) return false;
+	const m = value as Record<string, unknown>;
+	return typeof m.address === 'string' && typeof m.username === 'string';
 }
 
 function isRsvpStatus(value: unknown): value is RsvpStatus {
@@ -121,6 +142,9 @@ function parseFrame(raw: string): ChatFrame | null {
 	if (f.type === 'rsvp_update' && isRsvpEntry(f.rsvp)) {
 		return { type: 'rsvp_update', rsvp: f.rsvp };
 	}
+	if (f.type === 'roster_update' && Array.isArray(f.members) && f.members.every(isRoomMember)) {
+		return { type: 'roster_update', members: f.members as RoomMember[] };
+	}
 	return null;
 }
 
@@ -131,6 +155,8 @@ export interface ChatStore {
 	messages: Readable<ChatMessage[]>;
 	/** Current scheduled event (or null when none / not yet observed). */
 	event: Readable<RoomEventState | null>;
+	/** Live room roster (address + username), updated as members join/leave. */
+	members: Readable<RoomMember[]>;
 	send(content: string): void;
 	destroy(): void;
 }
@@ -138,6 +164,8 @@ export interface ChatStore {
 export interface CreateChatStoreOptions {
 	/** Initial event state from SSR, if any. Avoids a flash of empty content. */
 	initialEvent?: RoomEventState | null;
+	/** Initial member roster from SSR, used until the first WS update. */
+	initialMembers?: RoomMember[];
 }
 
 export function createChatStore(
@@ -147,6 +175,7 @@ export function createChatStore(
 ): ChatStore {
 	const messages = writable<ChatMessage[]>([]);
 	const event = writable<RoomEventState | null>(options.initialEvent ?? null);
+	const members = writable<RoomMember[]>(options.initialMembers ?? []);
 
 	let ws: WebSocket | null = null;
 	let reconnectTimeout: ReturnType<typeof setTimeout> | null = null;
@@ -199,6 +228,9 @@ export function createChatStore(
 				case 'rsvp_update':
 					applyRsvpUpdate(frame.rsvp);
 					break;
+				case 'roster_update':
+					members.set(frame.members);
+					break;
 			}
 		};
 
@@ -227,6 +259,7 @@ export function createChatStore(
 	return {
 		messages: { subscribe: messages.subscribe },
 		event: { subscribe: event.subscribe },
+		members: { subscribe: members.subscribe },
 		send(content: string) {
 			const trimmed = content.trim();
 			if (!trimmed || !ws || ws.readyState !== WebSocket.OPEN) return;

--- a/frontend/src/lib/components/RoomEvent.svelte
+++ b/frontend/src/lib/components/RoomEvent.svelte
@@ -1,0 +1,485 @@
+<script lang="ts">
+	import { enhance } from '$app/forms';
+	import type { RoomEventState, RsvpEntry, RsvpStatus } from '$lib/chatStore';
+
+	interface Props {
+		event: RoomEventState | null;
+		isCreator: boolean;
+		isMember: boolean;
+		viewerAddress: string;
+		members: { address: string; username?: string }[];
+	}
+
+	let {
+		event,
+		isCreator,
+		isMember,
+		viewerAddress,
+		members
+	}: Props = $props();
+
+	let editing = $state(false);
+	let draftStart = $state('');
+
+	const viewerLower = $derived(viewerAddress.toLowerCase());
+
+	const myRsvp: RsvpEntry | undefined = $derived(
+		event?.rsvps.find((r) => r.address.toLowerCase() === viewerLower)
+	);
+
+	function startEditing() {
+		editing = true;
+		draftStart = isoToLocalInput(event?.starts_at);
+	}
+
+	function cancelEditing() {
+		editing = false;
+		draftStart = '';
+	}
+
+	/**
+	 * Convert an ISO timestamp into the value expected by `<input type="datetime-local">`.
+	 * The backend stores UTC; the picker speaks the user's local time, so we
+	 * format relative to the local zone and strip the seconds.
+	 */
+	function isoToLocalInput(iso?: string): string {
+		if (!iso) {
+			const d = new Date(Date.now() + 30 * 60 * 1000);
+			return formatLocalForInput(d);
+		}
+		return formatLocalForInput(new Date(iso));
+	}
+
+	function formatLocalForInput(d: Date): string {
+		const pad = (n: number) => n.toString().padStart(2, '0');
+		return (
+			`${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}` +
+			`T${pad(d.getHours())}:${pad(d.getMinutes())}`
+		);
+	}
+
+	const startsAtFormatted = $derived.by(() => {
+		if (!event) return '';
+		try {
+			return new Intl.DateTimeFormat(undefined, {
+				weekday: 'short',
+				day: 'numeric',
+				month: 'short',
+				year: 'numeric',
+				hour: '2-digit',
+				minute: '2-digit'
+			}).format(new Date(event.starts_at));
+		} catch {
+			return event.starts_at;
+		}
+	});
+
+	let now = $state(new Date());
+
+	$effect(() => {
+		const id = setInterval(() => {
+			now = new Date();
+		}, 1000);
+		return () => clearInterval(id);
+	});
+
+	const countdown = $derived.by(() => {
+		if (!event) return '';
+		const diff = new Date(event.starts_at).getTime() - now.getTime();
+		if (diff <= 0) return 'STARTING NOW';
+		const totalSeconds = Math.floor(diff / 1000);
+		const days = Math.floor(totalSeconds / 86400);
+		const hours = Math.floor((totalSeconds % 86400) / 3600);
+		const minutes = Math.floor((totalSeconds % 3600) / 60);
+		const seconds = totalSeconds % 60;
+		const pad = (n: number) => n.toString().padStart(2, '0');
+		if (days > 0) return `${days}d ${pad(hours)}:${pad(minutes)}:${pad(seconds)}`;
+		return `${pad(hours)}:${pad(minutes)}:${pad(seconds)}`;
+	});
+
+	const rosterEntries = $derived.by(() => {
+		const rsvpByAddr: Record<string, RsvpEntry> = {};
+		for (const r of event?.rsvps ?? []) {
+			rsvpByAddr[r.address.toLowerCase()] = r;
+		}
+		return members.map((m) => {
+			const found = rsvpByAddr[m.address.toLowerCase()];
+			return {
+				address: m.address,
+				username: m.username ?? found?.username ?? shortAddr(m.address),
+				status: found?.status ?? null
+			};
+		});
+	});
+
+	function shortAddr(addr: string): string {
+		if (addr.length <= 10) return addr;
+		return `${addr.slice(0, 6)}…${addr.slice(-4)}`;
+	}
+
+	function statusLabel(status: RsvpStatus | null): string {
+		if (status === 'present') return 'PRESENT';
+		if (status === 'absent') return 'ABSENT';
+		if (status === 'maybe') return 'MAYBE';
+		return 'NO RESPONSE';
+	}
+</script>
+
+<section class="event-panel">
+	<div class="event-header">
+		<span class="eyebrow">— SCHEDULED EVENT</span>
+	</div>
+
+	{#if !event && !editing}
+		<div class="empty">
+			{#if isCreator}
+				<p class="empty-text">No event scheduled. Pick a moment for the warband.</p>
+				<button type="button" class="btn btn-primary" onclick={startEditing}>
+					[ SCHEDULE EVENT ]
+				</button>
+			{:else}
+				<p class="empty-text">No event scheduled yet. The room creator can pick a time.</p>
+			{/if}
+		</div>
+	{/if}
+
+	{#if event && !editing}
+		<div class="event-meta">
+			<div class="event-time">
+				<span class="time-value">{startsAtFormatted}</span>
+				<span class="countdown">{countdown}</span>
+			</div>
+			{#if isCreator}
+				<div class="creator-actions">
+					<button type="button" class="btn btn-secondary" onclick={startEditing}>
+						[ RESCHEDULE ]
+					</button>
+					<form
+						method="POST"
+						action="?/cancelEvent"
+						use:enhance
+						style="display: contents;"
+					>
+						<button type="submit" class="btn btn-danger">[ CANCEL EVENT ]</button>
+					</form>
+				</div>
+			{/if}
+		</div>
+
+		{#if isMember}
+			<div class="rsvp-controls">
+				<span class="rsvp-label">YOUR RSVP</span>
+				<div class="rsvp-buttons">
+					{#each ['present', 'maybe', 'absent'] as status (status)}
+						<form method="POST" action="?/setRsvp" use:enhance>
+							<input type="hidden" name="status" value={status} />
+							<button
+								type="submit"
+								class="rsvp-btn"
+								class:active={myRsvp?.status === status}
+								data-status={status}
+							>
+								[ {statusLabel(status as RsvpStatus)} ]
+							</button>
+						</form>
+					{/each}
+				</div>
+			</div>
+		{/if}
+
+		<div class="roster">
+			<span class="roster-label">RSVP ROSTER</span>
+			{#if rosterEntries.length === 0}
+				<p class="empty-text">No members yet.</p>
+			{:else}
+				<ul class="roster-list">
+					{#each rosterEntries as entry (entry.address)}
+						<li class="roster-row" data-status={entry.status ?? 'none'}>
+							<span class="roster-name">{entry.username}</span>
+							<span class="roster-status">{statusLabel(entry.status)}</span>
+						</li>
+					{/each}
+				</ul>
+			{/if}
+		</div>
+	{/if}
+
+	{#if editing}
+		<form
+			method="POST"
+			action="?/scheduleEvent"
+			class="schedule-form"
+			use:enhance={() => {
+				return async ({ update }) => {
+					await update();
+					editing = false;
+				};
+			}}
+		>
+			<label class="schedule-label">
+				<span class="rsvp-label">EVENT START (LOCAL TIME)</span>
+				<input
+					type="datetime-local"
+					name="starts_at"
+					bind:value={draftStart}
+					required
+				/>
+			</label>
+			<div class="schedule-actions">
+				<button type="submit" class="btn btn-primary">[ SAVE ]</button>
+				<button type="button" class="btn btn-secondary" onclick={cancelEditing}>
+					[ CANCEL ]
+				</button>
+			</div>
+		</form>
+	{/if}
+</section>
+
+<style>
+	.event-panel {
+		background: rgba(255, 255, 255, 0.03);
+		border: 1px solid rgba(227, 188, 116, 0.2);
+		border-radius: 12px;
+		padding: 1rem 1.2rem;
+		display: flex;
+		flex-direction: column;
+		gap: 0.9rem;
+	}
+
+	.event-header {
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+	}
+
+	.eyebrow,
+	.rsvp-label,
+	.roster-label {
+		font-family: ui-monospace, SFMono-Regular, monospace;
+		font-size: 0.7rem;
+		letter-spacing: 0.18em;
+		color: #8c877a;
+		text-transform: uppercase;
+	}
+
+	.empty {
+		border: 1px dashed rgba(227, 188, 116, 0.3);
+		border-radius: 8px;
+		padding: 1rem;
+		display: flex;
+		flex-direction: column;
+		gap: 0.6rem;
+		align-items: flex-start;
+	}
+
+	.empty-text {
+		margin: 0;
+		color: rgba(244, 236, 216, 0.6);
+		font-size: 0.9rem;
+	}
+
+	.event-meta {
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+		flex-wrap: wrap;
+		gap: 0.7rem;
+	}
+
+	.event-time {
+		display: flex;
+		flex-direction: column;
+		gap: 0.2rem;
+	}
+
+	.time-value {
+		font-family: 'Exocet', serif;
+		font-size: 1.4rem;
+		color: #f1e9cd;
+		letter-spacing: 0.02em;
+	}
+
+	.countdown {
+		font-family: ui-monospace, monospace;
+		font-size: 0.85rem;
+		color: #e3bc74;
+	}
+
+	.creator-actions {
+		display: flex;
+		gap: 0.5rem;
+	}
+
+	.rsvp-controls {
+		display: flex;
+		flex-direction: column;
+		gap: 0.5rem;
+	}
+
+	.rsvp-buttons {
+		display: flex;
+		gap: 0.5rem;
+		flex-wrap: wrap;
+	}
+
+	.rsvp-btn {
+		flex: 1;
+		min-width: 110px;
+		background: transparent;
+		border: 1px solid #28251e;
+		color: #8c877a;
+		padding: 0.55rem 0.8rem;
+		font-family: ui-monospace, monospace;
+		font-size: 0.7rem;
+		letter-spacing: 0.15em;
+		cursor: pointer;
+		border-radius: 4px;
+		transition:
+			border-color 0.2s,
+			color 0.2s,
+			background 0.2s;
+	}
+
+	.rsvp-btn:hover {
+		border-color: #e3bc74;
+		color: #e3bc74;
+	}
+
+	.rsvp-btn.active[data-status='present'] {
+		border-color: #a4ce82;
+		color: #1a1405;
+		background: #a4ce82;
+	}
+	.rsvp-btn.active[data-status='maybe'] {
+		border-color: #e3bc74;
+		color: #1a1405;
+		background: #e3bc74;
+	}
+	.rsvp-btn.active[data-status='absent'] {
+		border-color: #ff6b6b;
+		color: #1a1405;
+		background: #ff6b6b;
+	}
+
+	.roster {
+		display: flex;
+		flex-direction: column;
+		gap: 0.4rem;
+	}
+
+	.roster-list {
+		list-style: none;
+		margin: 0;
+		padding: 0;
+		display: flex;
+		flex-direction: column;
+		gap: 0.25rem;
+	}
+
+	.roster-row {
+		display: flex;
+		justify-content: space-between;
+		padding: 0.45rem 0.7rem;
+		background: rgba(0, 0, 0, 0.25);
+		border-radius: 4px;
+		font-family: ui-monospace, monospace;
+		font-size: 0.8rem;
+	}
+
+	.roster-name {
+		color: #f1e9cd;
+	}
+
+	.roster-status {
+		letter-spacing: 0.12em;
+	}
+
+	.roster-row[data-status='present'] .roster-status {
+		color: #a4ce82;
+	}
+	.roster-row[data-status='maybe'] .roster-status {
+		color: #e3bc74;
+	}
+	.roster-row[data-status='absent'] .roster-status {
+		color: #ff6b6b;
+	}
+	.roster-row[data-status='none'] .roster-status {
+		color: rgba(244, 236, 216, 0.4);
+	}
+
+	.schedule-form {
+		display: flex;
+		flex-direction: column;
+		gap: 0.7rem;
+	}
+
+	.schedule-label {
+		display: flex;
+		flex-direction: column;
+		gap: 0.35rem;
+	}
+
+	.schedule-form input[type='datetime-local'] {
+		background: #141415;
+		border: 1px solid #28251e;
+		color: #f1e9cd;
+		padding: 0.6rem;
+		border-radius: 4px;
+		font-family: ui-monospace, monospace;
+		font-size: 0.9rem;
+	}
+
+	.schedule-form input[type='datetime-local']:focus {
+		outline: none;
+		border-color: #e3bc74;
+	}
+
+	.schedule-actions {
+		display: flex;
+		gap: 0.5rem;
+	}
+
+	.btn {
+		font-family: ui-monospace, monospace;
+		font-size: 0.7rem;
+		letter-spacing: 0.15em;
+		padding: 0.55rem 0.9rem;
+		border-radius: 4px;
+		cursor: pointer;
+		text-transform: uppercase;
+		transition: all 0.2s;
+	}
+
+	.btn-primary {
+		background: #e3bc74;
+		color: #1a1405;
+		border: none;
+		font-weight: 600;
+	}
+
+	.btn-primary:hover {
+		background: #f1cf8f;
+	}
+
+	.btn-secondary {
+		background: transparent;
+		color: #a39c8c;
+		border: 1px solid #3d3930;
+	}
+
+	.btn-secondary:hover {
+		border-color: #e3bc74;
+		color: #e3bc74;
+	}
+
+	.btn-danger {
+		background: transparent;
+		color: #ff6b6b;
+		border: 1px solid rgba(255, 107, 107, 0.5);
+	}
+
+	.btn-danger:hover {
+		background: rgba(255, 107, 107, 0.1);
+		border-color: #ff6b6b;
+	}
+</style>

--- a/frontend/src/lib/components/RoomEvent.svelte
+++ b/frontend/src/lib/components/RoomEvent.svelte
@@ -11,14 +11,7 @@
 		formError?: string | null;
 	}
 
-	let {
-		event,
-		isCreator,
-		isMember,
-		viewerAddress,
-		members,
-		formError = null
-	}: Props = $props();
+	let { event, isCreator, isMember, viewerAddress, members, formError = null }: Props = $props();
 
 	let editing = $state(false);
 	let draftStart = $state('');

--- a/frontend/src/lib/components/RoomEvent.svelte
+++ b/frontend/src/lib/components/RoomEvent.svelte
@@ -8,6 +8,7 @@
 		isMember: boolean;
 		viewerAddress: string;
 		members: { address: string; username?: string }[];
+		formError?: string | null;
 	}
 
 	let {
@@ -15,11 +16,14 @@
 		isCreator,
 		isMember,
 		viewerAddress,
-		members
+		members,
+		formError = null
 	}: Props = $props();
 
 	let editing = $state(false);
 	let draftStart = $state('');
+	let draftEnd = $state('');
+	let localError = $state<string | null>(null);
 
 	const viewerLower = $derived(viewerAddress.toLowerCase());
 
@@ -29,25 +33,42 @@
 
 	function startEditing() {
 		editing = true;
-		draftStart = isoToLocalInput(event?.starts_at);
+		localError = null;
+		const startSeed = event?.starts_at
+			? new Date(event.starts_at)
+			: new Date(Date.now() + 30 * 60 * 1000);
+		const endSeed = event?.ends_at
+			? new Date(event.ends_at)
+			: new Date(startSeed.getTime() + 2 * 60 * 60 * 1000);
+		draftStart = formatLocalForInput(startSeed);
+		draftEnd = formatLocalForInput(endSeed);
 	}
 
 	function cancelEditing() {
 		editing = false;
 		draftStart = '';
+		draftEnd = '';
+		localError = null;
 	}
 
-	/**
-	 * Convert an ISO timestamp into the value expected by `<input type="datetime-local">`.
-	 * The backend stores UTC; the picker speaks the user's local time, so we
-	 * format relative to the local zone and strip the seconds.
-	 */
-	function isoToLocalInput(iso?: string): string {
-		if (!iso) {
-			const d = new Date(Date.now() + 30 * 60 * 1000);
-			return formatLocalForInput(d);
+	function validateDraft(): string | null {
+		if (!draftStart || !draftEnd) return 'Please pick both start and end times.';
+		const s = new Date(draftStart).getTime();
+		const e = new Date(draftEnd).getTime();
+		if (Number.isNaN(s) || Number.isNaN(e)) return 'Invalid date selection.';
+		if (e <= s) return 'End time must be after the start time.';
+		if (s <= Date.now()) return 'Start time must be in the future.';
+		return null;
+	}
+
+	function onSubmit(submitEvent: SubmitEvent) {
+		const err = validateDraft();
+		if (err) {
+			submitEvent.preventDefault();
+			localError = err;
+		} else {
+			localError = null;
 		}
-		return formatLocalForInput(new Date(iso));
 	}
 
 	function formatLocalForInput(d: Date): string {
@@ -58,8 +79,7 @@
 		);
 	}
 
-	const startsAtFormatted = $derived.by(() => {
-		if (!event) return '';
+	function fmtFull(iso: string): string {
 		try {
 			return new Intl.DateTimeFormat(undefined, {
 				weekday: 'short',
@@ -68,11 +88,25 @@
 				year: 'numeric',
 				hour: '2-digit',
 				minute: '2-digit'
-			}).format(new Date(event.starts_at));
+			}).format(new Date(iso));
 		} catch {
-			return event.starts_at;
+			return iso;
 		}
-	});
+	}
+
+	function fmtTime(iso: string): string {
+		try {
+			return new Intl.DateTimeFormat(undefined, {
+				hour: '2-digit',
+				minute: '2-digit'
+			}).format(new Date(iso));
+		} catch {
+			return iso;
+		}
+	}
+
+	const startsAtFormatted = $derived(event ? fmtFull(event.starts_at) : '');
+	const endsAtFormatted = $derived(event ? fmtTime(event.ends_at) : '');
 
 	let now = $state(new Date());
 
@@ -85,17 +119,27 @@
 
 	const countdown = $derived.by(() => {
 		if (!event) return '';
-		const diff = new Date(event.starts_at).getTime() - now.getTime();
-		if (diff <= 0) return 'STARTING NOW';
-		const totalSeconds = Math.floor(diff / 1000);
-		const days = Math.floor(totalSeconds / 86400);
-		const hours = Math.floor((totalSeconds % 86400) / 3600);
-		const minutes = Math.floor((totalSeconds % 3600) / 60);
-		const seconds = totalSeconds % 60;
-		const pad = (n: number) => n.toString().padStart(2, '0');
-		if (days > 0) return `${days}d ${pad(hours)}:${pad(minutes)}:${pad(seconds)}`;
-		return `${pad(hours)}:${pad(minutes)}:${pad(seconds)}`;
+		const startMs = new Date(event.starts_at).getTime();
+		const endMs = new Date(event.ends_at).getTime();
+		const t = now.getTime();
+		if (t >= endMs) return 'ENDED';
+		if (t >= startMs) {
+			const diff = Math.floor((endMs - t) / 1000);
+			return `IN PROGRESS — ${formatDelta(diff)} LEFT`;
+		}
+		const diff = Math.floor((startMs - t) / 1000);
+		return `STARTS IN ${formatDelta(diff)}`;
 	});
+
+	function formatDelta(seconds: number): string {
+		const days = Math.floor(seconds / 86400);
+		const hours = Math.floor((seconds % 86400) / 3600);
+		const minutes = Math.floor((seconds % 3600) / 60);
+		const secs = seconds % 60;
+		const pad = (n: number) => n.toString().padStart(2, '0');
+		if (days > 0) return `${days}d ${pad(hours)}:${pad(minutes)}:${pad(secs)}`;
+		return `${pad(hours)}:${pad(minutes)}:${pad(secs)}`;
+	}
 
 	const rosterEntries = $derived.by(() => {
 		const rsvpByAddr: Record<string, RsvpEntry> = {};
@@ -112,6 +156,17 @@
 		});
 	});
 
+	const rsvpCounts = $derived.by(() => {
+		const counts = { present: 0, maybe: 0, absent: 0, none: 0 };
+		for (const entry of rosterEntries) {
+			if (entry.status === 'present') counts.present += 1;
+			else if (entry.status === 'maybe') counts.maybe += 1;
+			else if (entry.status === 'absent') counts.absent += 1;
+			else counts.none += 1;
+		}
+		return counts;
+	});
+
 	function shortAddr(addr: string): string {
 		if (addr.length <= 10) return addr;
 		return `${addr.slice(0, 6)}…${addr.slice(-4)}`;
@@ -123,12 +178,18 @@
 		if (status === 'maybe') return 'MAYBE';
 		return 'NO RESPONSE';
 	}
+
+	const errorToShow = $derived(localError ?? formError ?? null);
 </script>
 
 <section class="event-panel">
 	<div class="event-header">
 		<span class="eyebrow">— SCHEDULED EVENT</span>
 	</div>
+
+	{#if errorToShow}
+		<p class="error-msg">{errorToShow}</p>
+	{/if}
 
 	{#if !event && !editing}
 		<div class="empty">
@@ -147,6 +208,7 @@
 		<div class="event-meta">
 			<div class="event-time">
 				<span class="time-value">{startsAtFormatted}</span>
+				<span class="time-end">→ ends {endsAtFormatted}</span>
 				<span class="countdown">{countdown}</span>
 			</div>
 			{#if isCreator}
@@ -154,12 +216,7 @@
 					<button type="button" class="btn btn-secondary" onclick={startEditing}>
 						[ RESCHEDULE ]
 					</button>
-					<form
-						method="POST"
-						action="?/cancelEvent"
-						use:enhance
-						style="display: contents;"
-					>
+					<form method="POST" action="?/cancelEvent" use:enhance style="display: contents;">
 						<button type="submit" class="btn btn-danger">[ CANCEL EVENT ]</button>
 					</form>
 				</div>
@@ -189,6 +246,24 @@
 
 		<div class="roster">
 			<span class="roster-label">RSVP ROSTER</span>
+			<div class="rsvp-summary">
+				<span class="summary-pill" data-status="present">
+					<span class="dot"></span>
+					{rsvpCounts.present} PRESENT
+				</span>
+				<span class="summary-pill" data-status="maybe">
+					<span class="dot"></span>
+					{rsvpCounts.maybe} MAYBE
+				</span>
+				<span class="summary-pill" data-status="absent">
+					<span class="dot"></span>
+					{rsvpCounts.absent} ABSENT
+				</span>
+				<span class="summary-pill" data-status="none">
+					<span class="dot"></span>
+					{rsvpCounts.none} NO RESPONSE
+				</span>
+			</div>
 			{#if rosterEntries.length === 0}
 				<p class="empty-text">No members yet.</p>
 			{:else}
@@ -209,21 +284,23 @@
 			method="POST"
 			action="?/scheduleEvent"
 			class="schedule-form"
+			onsubmit={onSubmit}
 			use:enhance={() => {
-				return async ({ update }) => {
+				return async ({ update, result }) => {
 					await update();
-					editing = false;
+					if (result.type === 'success') {
+						editing = false;
+					}
 				};
 			}}
 		>
 			<label class="schedule-label">
-				<span class="rsvp-label">EVENT START (LOCAL TIME)</span>
-				<input
-					type="datetime-local"
-					name="starts_at"
-					bind:value={draftStart}
-					required
-				/>
+				<span class="rsvp-label">START (LOCAL TIME)</span>
+				<input type="datetime-local" name="starts_at" bind:value={draftStart} required />
+			</label>
+			<label class="schedule-label">
+				<span class="rsvp-label">END (LOCAL TIME)</span>
+				<input type="datetime-local" name="ends_at" bind:value={draftEnd} required />
 			</label>
 			<div class="schedule-actions">
 				<button type="submit" class="btn btn-primary">[ SAVE ]</button>
@@ -262,6 +339,17 @@
 		text-transform: uppercase;
 	}
 
+	.error-msg {
+		margin: 0;
+		padding: 0.6rem 0.9rem;
+		border: 1px solid #ff6b6b;
+		background: rgba(255, 107, 107, 0.1);
+		border-radius: 4px;
+		color: #ff6b6b;
+		font-family: ui-monospace, monospace;
+		font-size: 0.8rem;
+	}
+
 	.empty {
 		border: 1px dashed rgba(227, 188, 116, 0.3);
 		border-radius: 8px;
@@ -293,10 +381,18 @@
 	}
 
 	.time-value {
-		font-family: 'Exocet', serif;
-		font-size: 1.4rem;
+		font-family: ui-monospace, SFMono-Regular, monospace;
+		font-size: 1.25rem;
 		color: #f1e9cd;
 		letter-spacing: 0.02em;
+		text-transform: uppercase;
+	}
+
+	.time-end {
+		font-family: ui-monospace, monospace;
+		font-size: 0.8rem;
+		color: rgba(244, 236, 216, 0.55);
+		letter-spacing: 0.06em;
 	}
 
 	.countdown {
@@ -365,6 +461,48 @@
 		display: flex;
 		flex-direction: column;
 		gap: 0.4rem;
+	}
+
+	.rsvp-summary {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 0.4rem;
+		margin-top: 0.2rem;
+	}
+
+	.summary-pill {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.4rem;
+		padding: 0.35rem 0.7rem;
+		border-radius: 999px;
+		background: rgba(0, 0, 0, 0.3);
+		border: 1px solid #28251e;
+		font-family: ui-monospace, monospace;
+		font-size: 0.7rem;
+		letter-spacing: 0.12em;
+		color: rgba(244, 236, 216, 0.7);
+	}
+
+	.summary-pill .dot {
+		width: 0.55rem;
+		height: 0.55rem;
+		border-radius: 50%;
+		background: #555;
+		flex-shrink: 0;
+	}
+
+	.summary-pill[data-status='present'] .dot {
+		background: #a4ce82;
+	}
+	.summary-pill[data-status='maybe'] .dot {
+		background: #e3bc74;
+	}
+	.summary-pill[data-status='absent'] .dot {
+		background: #ff6b6b;
+	}
+	.summary-pill[data-status='none'] .dot {
+		background: rgba(244, 236, 216, 0.3);
 	}
 
 	.roster-list {

--- a/frontend/src/routes/rooms/[name]/+page.server.ts
+++ b/frontend/src/routes/rooms/[name]/+page.server.ts
@@ -20,6 +20,7 @@ interface RoomDetail {
 	players_max: number;
 	players_active: number;
 	member_addresses: string[];
+	members: { address: string; username: string }[];
 	description: string | null;
 	communicator_link: string | null;
 	requirements: string | null;
@@ -74,6 +75,7 @@ export const load: PageServerLoad = async ({ params, cookies }) => {
 		address,
 		username,
 		memberAddresses: roomDetail.member_addresses,
+		members: roomDetail.members,
 		event: roomDetail.event,
 		isCreator: roomDetail.created_by.toLowerCase() === lower
 	};
@@ -98,12 +100,14 @@ export const actions: Actions = {
 
 		const data = await request.formData();
 		const startsAtRaw = data.get('starts_at');
-		if (typeof startsAtRaw !== 'string') {
-			return fail(400, { error: 'Missing start time' });
+		const endsAtRaw = data.get('ends_at');
+		if (typeof startsAtRaw !== 'string' || typeof endsAtRaw !== 'string') {
+			return fail(400, { error: 'Missing start or end time' });
 		}
-		const isoUtc = localInputToIsoUtc(startsAtRaw);
-		if (!isoUtc) {
-			return fail(400, { error: 'Invalid start time' });
+		const startIso = localInputToIsoUtc(startsAtRaw);
+		const endIso = localInputToIsoUtc(endsAtRaw);
+		if (!startIso || !endIso) {
+			return fail(400, { error: 'Invalid start or end time' });
 		}
 
 		const baseUrl = backendBase();
@@ -116,7 +120,7 @@ export const actions: Actions = {
 						'Content-Type': 'application/json',
 						Authorization: `Bearer ${session}`
 					},
-					body: JSON.stringify({ starts_at: isoUtc })
+					body: JSON.stringify({ starts_at: startIso, ends_at: endIso })
 				}
 			);
 			if (!res.ok) {

--- a/frontend/src/routes/rooms/[name]/+page.server.ts
+++ b/frontend/src/routes/rooms/[name]/+page.server.ts
@@ -1,8 +1,9 @@
-import type { PageServerLoad } from './$types';
+import type { Actions, PageServerLoad } from './$types';
 import { env } from '$env/dynamic/public';
 import { env as privateEnv } from '$env/dynamic/private';
-import { redirect } from '@sveltejs/kit';
+import { fail, redirect } from '@sveltejs/kit';
 import { jwtDecode } from 'jwt-decode';
+import type { RoomEventState } from '$lib/chatStore';
 
 function backendBase(): string {
 	return privateEnv.BACKEND_INTERNAL_URL || env.PUBLIC_BACKEND_URL || 'http://localhost:8000';
@@ -22,7 +23,9 @@ interface RoomDetail {
 	description: string | null;
 	communicator_link: string | null;
 	requirements: string | null;
+	created_by: string;
 	expires_at: string;
+	event: RoomEventState | null;
 }
 
 export const load: PageServerLoad = async ({ params, cookies }) => {
@@ -41,36 +44,144 @@ export const load: PageServerLoad = async ({ params, cookies }) => {
 	if (!address) throw redirect(303, '/auth');
 
 	const baseUrl = backendBase();
-	let isMember = false;
-	let roomGame = '';
-	let description: string | null = null;
-	let communicatorLink: string | null = null;
-	let requirements: string | null = null;
+	let roomDetail: RoomDetail | null = null;
 	try {
 		const res = await fetch(`${baseUrl}/rooms/${encodeURIComponent(params.name)}`);
 		if (res.ok) {
-			const data = (await res.json()) as RoomDetail;
-			roomGame = data.game;
-			description = data.description;
-			communicatorLink = data.communicator_link;
-			requirements = data.requirements;
-			const lower = address.toLowerCase();
-			isMember = data.member_addresses.some((a) => a.toLowerCase() === lower);
+			roomDetail = (await res.json()) as RoomDetail;
 		}
 	} catch {
-		// treat fetch errors as non-member; will redirect below
+		// treat fetch errors as missing room — fall through to redirect
 	}
 
-	if (!isMember) throw redirect(303, '/rooms');
+	if (!roomDetail) {
+		throw redirect(303, '/rooms');
+	}
+
+	const lower = address.toLowerCase();
+	const isMember = roomDetail.member_addresses.some((a) => a.toLowerCase() === lower);
+	if (!isMember) {
+		throw redirect(303, '/rooms');
+	}
 
 	return {
-		roomName: params.name,
-		roomGame,
-		description,
-		communicatorLink,
-		requirements,
+		roomName: roomDetail.name,
+		roomGame: roomDetail.game,
+		description: roomDetail.description,
+		communicatorLink: roomDetail.communicator_link,
+		requirements: roomDetail.requirements,
 		token: session,
 		address,
-		username
+		username,
+		memberAddresses: roomDetail.member_addresses,
+		event: roomDetail.event,
+		isCreator: roomDetail.created_by.toLowerCase() === lower
 	};
+};
+
+const VALID_RSVP = new Set(['present', 'absent', 'maybe']);
+
+function localInputToIsoUtc(value: string): string | null {
+	// `<input type="datetime-local">` produces values like "2026-06-02T18:30",
+	// interpreted in the user's local zone. `new Date(value)` honours that and
+	// .toISOString() converts to the UTC ISO form the backend expects.
+	if (!value) return null;
+	const d = new Date(value);
+	if (Number.isNaN(d.getTime())) return null;
+	return d.toISOString();
+}
+
+export const actions: Actions = {
+	scheduleEvent: async ({ request, cookies, params }) => {
+		const session = cookies.get('session');
+		if (!session) return fail(401, { error: 'Not authenticated' });
+
+		const data = await request.formData();
+		const startsAtRaw = data.get('starts_at');
+		if (typeof startsAtRaw !== 'string') {
+			return fail(400, { error: 'Missing start time' });
+		}
+		const isoUtc = localInputToIsoUtc(startsAtRaw);
+		if (!isoUtc) {
+			return fail(400, { error: 'Invalid start time' });
+		}
+
+		const baseUrl = backendBase();
+		try {
+			const res = await fetch(
+				`${baseUrl}/rooms/${encodeURIComponent(params.name)}/event`,
+				{
+					method: 'PUT',
+					headers: {
+						'Content-Type': 'application/json',
+						Authorization: `Bearer ${session}`
+					},
+					body: JSON.stringify({ starts_at: isoUtc })
+				}
+			);
+			if (!res.ok) {
+				const result = await res.json().catch(() => ({}));
+				return fail(res.status, { error: result.detail || 'Failed to schedule event' });
+			}
+			return { success: true, message: 'Event scheduled' };
+		} catch {
+			return fail(500, { error: 'Server error' });
+		}
+	},
+
+	cancelEvent: async ({ cookies, params }) => {
+		const session = cookies.get('session');
+		if (!session) return fail(401, { error: 'Not authenticated' });
+
+		const baseUrl = backendBase();
+		try {
+			const res = await fetch(
+				`${baseUrl}/rooms/${encodeURIComponent(params.name)}/event`,
+				{
+					method: 'DELETE',
+					headers: { Authorization: `Bearer ${session}` }
+				}
+			);
+			if (!res.ok) {
+				const result = await res.json().catch(() => ({}));
+				return fail(res.status, { error: result.detail || 'Failed to cancel event' });
+			}
+			return { success: true, message: 'Event cancelled' };
+		} catch {
+			return fail(500, { error: 'Server error' });
+		}
+	},
+
+	setRsvp: async ({ request, cookies, params }) => {
+		const session = cookies.get('session');
+		if (!session) return fail(401, { error: 'Not authenticated' });
+
+		const data = await request.formData();
+		const status = data.get('status');
+		if (typeof status !== 'string' || !VALID_RSVP.has(status)) {
+			return fail(400, { error: 'Invalid RSVP status' });
+		}
+
+		const baseUrl = backendBase();
+		try {
+			const res = await fetch(
+				`${baseUrl}/rooms/${encodeURIComponent(params.name)}/event/rsvp`,
+				{
+					method: 'PUT',
+					headers: {
+						'Content-Type': 'application/json',
+						Authorization: `Bearer ${session}`
+					},
+					body: JSON.stringify({ status })
+				}
+			);
+			if (!res.ok) {
+				const result = await res.json().catch(() => ({}));
+				return fail(res.status, { error: result.detail || 'Failed to set RSVP' });
+			}
+			return { success: true, message: 'RSVP saved' };
+		} catch {
+			return fail(500, { error: 'Server error' });
+		}
+	}
 };

--- a/frontend/src/routes/rooms/[name]/+page.server.ts
+++ b/frontend/src/routes/rooms/[name]/+page.server.ts
@@ -112,17 +112,14 @@ export const actions: Actions = {
 
 		const baseUrl = backendBase();
 		try {
-			const res = await fetch(
-				`${baseUrl}/rooms/${encodeURIComponent(params.name)}/event`,
-				{
-					method: 'PUT',
-					headers: {
-						'Content-Type': 'application/json',
-						Authorization: `Bearer ${session}`
-					},
-					body: JSON.stringify({ starts_at: startIso, ends_at: endIso })
-				}
-			);
+			const res = await fetch(`${baseUrl}/rooms/${encodeURIComponent(params.name)}/event`, {
+				method: 'PUT',
+				headers: {
+					'Content-Type': 'application/json',
+					Authorization: `Bearer ${session}`
+				},
+				body: JSON.stringify({ starts_at: startIso, ends_at: endIso })
+			});
 			if (!res.ok) {
 				const result = await res.json().catch(() => ({}));
 				return fail(res.status, { error: result.detail || 'Failed to schedule event' });
@@ -139,13 +136,10 @@ export const actions: Actions = {
 
 		const baseUrl = backendBase();
 		try {
-			const res = await fetch(
-				`${baseUrl}/rooms/${encodeURIComponent(params.name)}/event`,
-				{
-					method: 'DELETE',
-					headers: { Authorization: `Bearer ${session}` }
-				}
-			);
+			const res = await fetch(`${baseUrl}/rooms/${encodeURIComponent(params.name)}/event`, {
+				method: 'DELETE',
+				headers: { Authorization: `Bearer ${session}` }
+			});
 			if (!res.ok) {
 				const result = await res.json().catch(() => ({}));
 				return fail(res.status, { error: result.detail || 'Failed to cancel event' });
@@ -168,17 +162,14 @@ export const actions: Actions = {
 
 		const baseUrl = backendBase();
 		try {
-			const res = await fetch(
-				`${baseUrl}/rooms/${encodeURIComponent(params.name)}/event/rsvp`,
-				{
-					method: 'PUT',
-					headers: {
-						'Content-Type': 'application/json',
-						Authorization: `Bearer ${session}`
-					},
-					body: JSON.stringify({ status })
-				}
-			);
+			const res = await fetch(`${baseUrl}/rooms/${encodeURIComponent(params.name)}/event/rsvp`, {
+				method: 'PUT',
+				headers: {
+					'Content-Type': 'application/json',
+					Authorization: `Bearer ${session}`
+				},
+				body: JSON.stringify({ status })
+			});
 			if (!res.ok) {
 				const result = await res.json().catch(() => ({}));
 				return fail(res.status, { error: result.detail || 'Failed to set RSVP' });

--- a/frontend/src/routes/rooms/[name]/+page.svelte
+++ b/frontend/src/routes/rooms/[name]/+page.svelte
@@ -1,24 +1,43 @@
 <script lang="ts">
 	import { onDestroy, onMount, tick } from 'svelte';
 	import type { PageData } from './$types';
-	import { createChatStore, type ChatMessage, type ChatStore } from '$lib/chatStore';
+	import {
+		createChatStore,
+		type ChatMessage,
+		type ChatStore,
+		type RoomEventState
+	} from '$lib/chatStore';
+	import RoomEvent from '$lib/components/RoomEvent.svelte';
 
 	let { data }: { data: PageData } = $props();
 
 	let chat = $state<ChatStore | null>(null);
 	let messages = $state<ChatMessage[]>([]);
+	let event = $state<RoomEventState | null>(null);
 	let input = $state('');
 	let scroller: HTMLDivElement | null = $state(null);
 
+	const members = $derived(
+		data.memberAddresses.map((address) => ({ address }))
+	);
+
 	onMount(() => {
-		const store = createChatStore(data.roomName, data.token);
+		const store = createChatStore(data.roomName, data.token, {
+			initialEvent: data.event
+		});
 		chat = store;
-		const unsubscribe = store.subscribe(async (m) => {
+		const unsubMessages = store.messages.subscribe(async (m) => {
 			messages = m;
 			await tick();
 			if (scroller) scroller.scrollTop = scroller.scrollHeight;
 		});
-		return unsubscribe;
+		const unsubEvent = store.event.subscribe((e) => {
+			event = e;
+		});
+		return () => {
+			unsubMessages();
+			unsubEvent();
+		};
 	});
 
 	onDestroy(() => {
@@ -84,6 +103,14 @@
 			</div>
 		{/if}
 	</header>
+
+	<RoomEvent
+		{event}
+		isCreator={data.isCreator}
+		isMember={true}
+		viewerAddress={data.address}
+		{members}
+	/>
 
 	<div class="chat" bind:this={scroller}>
 		{#if messages.length === 0}
@@ -216,8 +243,8 @@
 
 	.chat {
 		flex: 1;
-		min-height: 50vh;
-		max-height: 65vh;
+		min-height: 40vh;
+		max-height: 55vh;
 		overflow-y: auto;
 		padding: 1rem;
 		background: rgba(255, 255, 255, 0.03);

--- a/frontend/src/routes/rooms/[name]/+page.svelte
+++ b/frontend/src/routes/rooms/[name]/+page.svelte
@@ -9,7 +9,7 @@
 	} from '$lib/chatStore';
 	import RoomEvent from '$lib/components/RoomEvent.svelte';
 
-	let { data }: { data: PageData } = $props();
+	let { data, form }: { data: PageData; form: { error?: string } | null } = $props();
 
 	let chat = $state<ChatStore | null>(null);
 	let messages = $state<ChatMessage[]>([]);
@@ -17,9 +17,7 @@
 	let input = $state('');
 	let scroller: HTMLDivElement | null = $state(null);
 
-	const members = $derived(
-		data.memberAddresses.map((address) => ({ address }))
-	);
+	const members = $derived(data.members);
 
 	onMount(() => {
 		const store = createChatStore(data.roomName, data.token, {
@@ -110,6 +108,7 @@
 		isMember={true}
 		viewerAddress={data.address}
 		{members}
+		formError={form?.error ?? null}
 	/>
 
 	<div class="chat" bind:this={scroller}>

--- a/frontend/src/routes/rooms/[name]/+page.svelte
+++ b/frontend/src/routes/rooms/[name]/+page.svelte
@@ -5,7 +5,8 @@
 		createChatStore,
 		type ChatMessage,
 		type ChatStore,
-		type RoomEventState
+		type RoomEventState,
+		type RoomMember
 	} from '$lib/chatStore';
 	import RoomEvent from '$lib/components/RoomEvent.svelte';
 
@@ -14,14 +15,14 @@
 	let chat = $state<ChatStore | null>(null);
 	let messages = $state<ChatMessage[]>([]);
 	let event = $state<RoomEventState | null>(null);
+	let members = $state<RoomMember[]>(data.members);
 	let input = $state('');
 	let scroller: HTMLDivElement | null = $state(null);
 
-	const members = $derived(data.members);
-
 	onMount(() => {
 		const store = createChatStore(data.roomName, data.token, {
-			initialEvent: data.event
+			initialEvent: data.event,
+			initialMembers: data.members
 		});
 		chat = store;
 		const unsubMessages = store.messages.subscribe(async (m) => {
@@ -32,9 +33,13 @@
 		const unsubEvent = store.event.subscribe((e) => {
 			event = e;
 		});
+		const unsubMembers = store.members.subscribe((m) => {
+			members = m;
+		});
 		return () => {
 			unsubMessages();
 			unsubEvent();
+			unsubMembers();
 		};
 	});
 


### PR DESCRIPTION
## What

Adds scheduled events with RSVP per room.

- New endpoints: `PUT/DELETE/GET /rooms/{name}/event`, `PUT /rooms/{name}/event/rsvp`
- New tables: `roomevent` (one per room, with `starts_at` + `ends_at`), `roomeventrsvp` (one per user/event, statuses `present`/`maybe`/`absent`)
- Realtime: `event_update`, `rsvp_update`, `roster_update` frames over the existing `/ws/rooms/{name}/chat` channel
- Frontend: minimal `RoomEvent.svelte` panel above chat — schedule form for the creator, RSVP buttons + roster + summary counts for members
- Scheduling auto-extends `room.expires_at` past `ends_at + 30min` so the room outlives the event
- `leave_room` clears the user's RSVP and broadcasts an updated roster

UI polishing is intentionally minimal — visual refactor is being handled in a separate branch.

## Tested

- 51 backend tests pass (`uv run pytest`), ruff clean
- ESLint clean
- Manual browser flow: schedule, reschedule, cancel, RSVP per status, second-user join updates roster live

Closes #62