### PR TITLE
feat: editable unique username with profanity stoplist (#56)

### DIFF
--- a/backend/data/profanity_en.txt
+++ b/backend/data/profanity_en.txt
@@ -1,0 +1,403 @@
+2g1c
+2 girls 1 cup
+acrotomophilia
+alabama hot pocket
+alaskan pipeline
+anal
+anilingus
+anus
+apeshit
+arsehole
+ass
+asshole
+assmunch
+auto erotic
+autoerotic
+babeland
+baby batter
+baby juice
+ball gag
+ball gravy
+ball kicking
+ball licking
+ball sack
+ball sucking
+bangbros
+bangbus
+bareback
+barely legal
+barenaked
+bastard
+bastardo
+bastinado
+bbw
+bdsm
+beaner
+beaners
+beaver cleaver
+beaver lips
+beastiality
+bestiality
+big black
+big breasts
+big knockers
+big tits
+bimbos
+birdlock
+bitch
+bitches
+black cock
+blonde action
+blonde on blonde action
+blowjob
+blow job
+blow your load
+blue waffle
+blumpkin
+bollocks
+bondage
+boner
+boob
+boobs
+booty call
+brown showers
+brunette action
+bukkake
+bulldyke
+bullet vibe
+bullshit
+bung hole
+bunghole
+busty
+butt
+buttcheeks
+butthole
+camel toe
+camgirl
+camslut
+camwhore
+carpet muncher
+carpetmuncher
+chocolate rosebuds
+cialis
+circlejerk
+cleveland steamer
+clit
+clitoris
+clover clamps
+clusterfuck
+cock
+cocks
+coprolagnia
+coprophilia
+cornhole
+coon
+coons
+creampie
+cum
+cumming
+cumshot
+cumshots
+cunnilingus
+cunt
+darkie
+date rape
+daterape
+deep throat
+deepthroat
+dendrophilia
+dick
+dildo
+dingleberry
+dingleberries
+dirty pillows
+dirty sanchez
+doggie style
+doggiestyle
+doggy style
+doggystyle
+dog style
+dolcett
+domination
+dominatrix
+dommes
+donkey punch
+double dong
+double penetration
+dp action
+dry hump
+dvda
+eat my ass
+ecchi
+ejaculation
+erotic
+erotism
+escort
+eunuch
+fag
+faggot
+fecal
+felch
+fellatio
+feltch
+female squirting
+femdom
+figging
+fingerbang
+fingering
+fisting
+foot fetish
+footjob
+frotting
+fuck
+fuck buttons
+fuckin
+fucking
+fucktards
+fudge packer
+fudgepacker
+futanari
+gangbang
+gang bang
+gay sex
+genitals
+giant cock
+girl on
+girl on top
+girls gone wild
+goatcx
+goatse
+god damn
+gokkun
+golden shower
+goodpoop
+goo girl
+goregasm
+grope
+group sex
+g-spot
+guro
+hand job
+handjob
+hard core
+hardcore
+hentai
+homoerotic
+honkey
+hooker
+horny
+hot carl
+hot chick
+how to kill
+how to murder
+huge fat
+humping
+incest
+intercourse
+jack off
+jail bait
+jailbait
+jelly donut
+jerk off
+jigaboo
+jiggaboo
+jiggerboo
+jizz
+juggs
+kike
+kinbaku
+kinkster
+kinky
+knobbing
+leather restraint
+leather straight jacket
+lemon party
+livesex
+lolita
+lovemaking
+make me come
+male squirting
+masturbate
+masturbating
+masturbation
+menage a trois
+milf
+missionary position
+mong
+motherfucker
+mound of venus
+mr hands
+muff diver
+muffdiving
+nambla
+nawashi
+negro
+neonazi
+nigga
+nigger
+nig nog
+nimphomania
+nipple
+nipples
+nsfw
+nsfw images
+nude
+nudity
+nutten
+nympho
+nymphomania
+octopussy
+omorashi
+one cup two girls
+one guy one jar
+orgasm
+orgy
+paedophile
+paki
+panties
+panty
+pedobear
+pedophile
+pegging
+penis
+phone sex
+piece of shit
+pikey
+pissing
+piss pig
+pisspig
+playboy
+pleasure chest
+pole smoker
+ponyplay
+poof
+poon
+poontang
+punany
+poop chute
+poopchute
+porn
+porno
+pornography
+prince albert piercing
+pthc
+pubes
+pussy
+queaf
+queef
+quim
+raghead
+raging boner
+rape
+raping
+rapist
+rectum
+reverse cowgirl
+rimjob
+rimming
+rosy palm
+rosy palm and her 5 sisters
+rusty trombone
+sadism
+santorum
+scat
+schlong
+scissoring
+semen
+sex
+sexcam
+sexo
+sexy
+sexual
+sexually
+sexuality
+shaved beaver
+shaved pussy
+shemale
+shibari
+shit
+shitblimp
+shitty
+shota
+shrimping
+skeet
+slanteye
+slut
+s&m
+smut
+snatch
+snowballing
+sodomize
+sodomy
+spastic
+spic
+splooge
+splooge moose
+spooge
+spread legs
+spunk
+strap on
+strapon
+strappado
+strip club
+style doggy
+suck
+sucks
+suicide girls
+sultry women
+swastika
+swinger
+tainted love
+taste my
+tea bagging
+threesome
+throating
+thumbzilla
+tied up
+tight white
+tit
+tits
+titties
+titty
+tongue in a
+topless
+tosser
+towelhead
+tranny
+tribadism
+tub girl
+tubgirl
+tushy
+twat
+twink
+twinkie
+two girls one cup
+undressing
+upskirt
+urethra play
+urophilia
+vagina
+venus mound
+viagra
+vibrator
+violet wand
+vorarephilia
+voyeur
+voyeurweb
+voyuer
+vulva
+wank
+wetback
+wet dream
+white power
+whore
+worldsex
+wrapping men
+wrinkled starfish
+xx
+xxx
+yaoi
+yellow showers
+yiffy
+zoophilia
+🖕

--- a/backend/main.py
+++ b/backend/main.py
@@ -17,6 +17,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.security import OAuth2PasswordBearer
 from pydantic import BaseModel, HttpUrl
 from pydantic import Field as PydField
+from sqlalchemy.exc import IntegrityError
 from sqlmodel import Session, select
 
 from database import get_session
@@ -30,6 +31,7 @@ from models import (
     RsvpStatus,
     User,
 )
+from usernames import validate_username
 
 # Load .env from project root if it exists
 env_path = Path(__file__).parent.parent / ".env"
@@ -502,6 +504,22 @@ def verify_signature(body: VerifyRequest, session: SessionDep):
     }
 
 
+def _user_payload(user: User) -> dict:
+    """Public-facing serialization of a user (shared by GET/PATCH /users/me)."""
+    return {
+        "id": user.id,
+        "identity_address": user.identity_address,
+        "username": user.username,
+        "created_at": _iso(user.created_at),
+        "last_login": _iso(user.last_login) if user.last_login else None,
+        "is_admin": is_admin_address(user.identity_address),
+    }
+
+
+class UpdateUserRequest(BaseModel):
+    username: str
+
+
 @app.get("/users/me")
 def get_me(
     session: SessionDep,
@@ -510,14 +528,48 @@ def get_me(
     user = session.exec(select(User).where(User.identity_address == address)).first()
     if not user:
         raise HTTPException(status_code=404, detail="User not found")
-    return {
-        "id": user.id,
-        "identity_address": user.identity_address,
-        "username": user.username,
-        "created_at": _iso(user.created_at),
-        "last_login": _iso(user.last_login) if user.last_login else None,
-        "is_admin": is_admin_address(address),
-    }
+    return _user_payload(user)
+
+
+@app.patch("/users/me")
+def update_me(
+    payload: UpdateUserRequest,
+    session: SessionDep,
+    address: Annotated[str, Depends(get_current_user_address)],
+):
+    user = session.exec(select(User).where(User.identity_address == address)).first()
+    if not user:
+        raise HTTPException(status_code=404, detail="User not found")
+
+    username = payload.username.strip()
+
+    error = validate_username(username)
+    if error == "invalid_format":
+        raise HTTPException(
+            status_code=400,
+            detail="Username must be 3-20 characters: letters, numbers, _ or -.",
+        )
+    if error == "profane":
+        raise HTTPException(
+            status_code=400, detail="Username contains inappropriate language."
+        )
+
+    if username == user.username:
+        return _user_payload(user)
+
+    existing = session.exec(select(User).where(User.username == username)).first()
+    if existing is not None:
+        raise HTTPException(status_code=409, detail="Username already taken.")
+
+    user.username = username
+    session.add(user)
+    try:
+        session.commit()
+    except IntegrityError:
+        session.rollback()
+        raise HTTPException(status_code=409, detail="Username already taken.") from None
+    session.refresh(user)
+    return _user_payload(user)
 
 
 @app.get("/rooms")

--- a/backend/tests/test_users.py
+++ b/backend/tests/test_users.py
@@ -1,0 +1,141 @@
+import os
+from datetime import UTC, datetime, timedelta
+
+import jwt
+from fastapi.testclient import TestClient
+from sqlmodel import Session, select
+
+from models import User
+from usernames import contains_profanity, load_stoplist, validate_username
+
+
+def _mint_token(address: str) -> str:
+    secret = os.environ["JWT_SECRET"]
+    payload = {
+        "sub": address,
+        "iat": datetime.now(UTC),
+        "exp": datetime.now(UTC) + timedelta(minutes=5),
+        "iss": "playlink-auth",
+    }
+    return jwt.encode(payload, secret, algorithm="HS256")
+
+
+def _make_user(session: Session, address: str, username: str | None = None) -> User:
+    user = User(identity_address=address)
+    if username is not None:
+        user.username = username
+    session.add(user)
+    session.commit()
+    session.refresh(user)
+    return user
+
+
+# --- unit: stoplist / validation -------------------------------------------
+
+
+def test_stoplist_loads_non_empty():
+    assert len(load_stoplist()) > 0
+
+
+def test_contains_profanity_exact_and_case_insensitive():
+    assert contains_profanity("fuck")
+    assert contains_profanity("FUCK")
+
+
+def test_contains_profanity_token_split():
+    assert contains_profanity("xX_fuck_Xx")
+    assert contains_profanity("pro-shit-gamer")
+
+
+def test_contains_profanity_avoids_false_positives():
+    # 'ass' substring appears but is not a standalone token
+    assert not contains_profanity("assassin")
+    assert not contains_profanity("classic_gamer")
+
+
+def test_validate_username_rejects_format_and_profanity():
+    assert validate_username("ab") == "invalid_format"  # too short
+    assert validate_username("has spaces") == "invalid_format"
+    assert validate_username("a" * 21) == "invalid_format"
+    assert validate_username("fuck") == "profane"
+    assert validate_username("CoolGamer_99") is None
+
+
+# --- endpoint: PATCH /users/me ---------------------------------------------
+
+
+def test_update_username_success(client: TestClient, session: Session):
+    addr = "0xAbc0000000000000000000000000000000000001"
+    _make_user(session, addr)
+    token = _mint_token(addr)
+
+    resp = client.patch(
+        "/users/me",
+        json={"username": "NightRaven_7"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["username"] == "NightRaven_7"
+
+    refreshed = session.exec(select(User).where(User.identity_address == addr)).first()
+    assert refreshed.username == "NightRaven_7"
+
+
+def test_update_username_idempotent_same_value(client: TestClient, session: Session):
+    addr = "0xAbc0000000000000000000000000000000000002"
+    _make_user(session, addr, username="StableName")
+    token = _mint_token(addr)
+
+    resp = client.patch(
+        "/users/me",
+        json={"username": "StableName"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["username"] == "StableName"
+
+
+def test_update_username_invalid_format(client: TestClient, session: Session):
+    addr = "0xAbc0000000000000000000000000000000000003"
+    _make_user(session, addr)
+    token = _mint_token(addr)
+
+    resp = client.patch(
+        "/users/me",
+        json={"username": "no"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 400
+
+
+def test_update_username_profane(client: TestClient, session: Session):
+    addr = "0xAbc0000000000000000000000000000000000004"
+    _make_user(session, addr)
+    token = _mint_token(addr)
+
+    resp = client.patch(
+        "/users/me",
+        json={"username": "FuCk"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 400
+
+
+def test_update_username_conflict(client: TestClient, session: Session):
+    taken_addr = "0xAbc0000000000000000000000000000000000005"
+    mine_addr = "0xAbc0000000000000000000000000000000000006"
+    _make_user(session, taken_addr, username="Taken_Name")
+    _make_user(session, mine_addr)
+    token = _mint_token(mine_addr)
+
+    resp = client.patch(
+        "/users/me",
+        json={"username": "Taken_Name"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 409
+
+
+def test_update_username_unauthenticated(client: TestClient):
+    resp = client.patch("/users/me", json={"username": "Whoever"})
+    assert resp.status_code == 401

--- a/backend/usernames.py
+++ b/backend/usernames.py
@@ -1,0 +1,52 @@
+"""Username validation: format rules and a public profanity stoplist.
+
+The stoplist is the LDNOOBW English word list, vendored at
+``data/profanity_en.txt`` so the check is offline and version-pinned.
+
+Source: https://github.com/LDNOOBW/List-of-Dirty-Naughty-Obscene-and-Otherwise-Bad-Words
+File ``en``, git blob ``a438b9ca33af77341768bd6c63ce3e48e726b76e``,
+retrieved 2026-05-29.
+"""
+
+import re
+from functools import lru_cache
+from pathlib import Path
+
+USERNAME_RE = re.compile(r"^[a-zA-Z0-9_-]{3,20}$")
+
+_STOPLIST_PATH = Path(__file__).parent / "data" / "profanity_en.txt"
+_TOKEN_SPLIT = re.compile(r"[_-]")
+
+
+@lru_cache(maxsize=1)
+def load_stoplist() -> frozenset[str]:
+    """Load the profanity stoplist once, lowercased, blanks dropped."""
+    lines = _STOPLIST_PATH.read_text(encoding="utf-8").splitlines()
+    return frozenset(word.strip().lower() for word in lines if word.strip())
+
+
+def contains_profanity(name: str) -> bool:
+    """True if ``name`` as a whole, or any ``_``/``-`` token, is a stoplist word.
+
+    Exact whole-string and per-token matching (rather than substring) avoids
+    false positives like ``assassin`` or ``classic`` while still catching
+    evasions such as ``xX_fuck_Xx``.
+    """
+    stoplist = load_stoplist()
+    lowered = name.lower()
+    if lowered in stoplist:
+        return True
+    return any(token in stoplist for token in _TOKEN_SPLIT.split(lowered) if token)
+
+
+def validate_username(name: str) -> str | None:
+    """Return an error code, or ``None`` when valid.
+
+    Codes: ``"invalid_format"`` (fails the regex), ``"profane"`` (hits the
+    stoplist).
+    """
+    if not USERNAME_RE.match(name):
+        return "invalid_format"
+    if contains_profanity(name):
+        return "profane"
+    return None

--- a/docs/superpowers/specs/2026-05-29-username-editing-design.md
+++ b/docs/superpowers/specs/2026-05-29-username-editing-design.md
@@ -1,0 +1,82 @@
+# Issue #56 — Username editing with profanity stoplist
+
+## Goal
+Let an authenticated user set a custom, unique username (replacing the
+auto-generated `user_<hex>`), validated against a public profanity stoplist
+before saving. Usernames are public (chat, room rosters, RSVP lists), so basic
+moderation is required.
+
+## Existing state (no change needed)
+- `User.username` is already `unique`, `index`, defaulting to `user_<hex>`
+  (`backend/models.py`). It is part of the initial Alembic migration, so no DB
+  migration is required.
+- `GET /users/me` returns `{ id, identity_address, username, created_at,
+  last_login, is_admin }`.
+- Username already surfaces live in chat, rosters, and RSVPs (looked up by
+  address), so an edit propagates automatically — no backfill needed.
+- Auth: SvelteKit stores the JWT in a `session` cookie; server `load`/actions
+  call the backend with `Authorization: Bearer ${session}`.
+
+## Backend
+
+### Stoplist (vendored)
+- File: `backend/data/profanity_en.txt` — the LDNOOBW English list, one entry
+  per line.
+- Source: https://github.com/LDNOOBW/List-of-Dirty-Naughty-Obscene-and-Otherwise-Bad-Words
+  file `en`, git blob `a438b9ca33af77341768bd6c63ce3e48e726b76e`, retrieved
+  2026-05-29. Documented in the loader module.
+
+### `backend/usernames.py`
+- `USERNAME_RE = re.compile(r"^[a-zA-Z0-9_-]{3,20}$")`
+- `load_stoplist() -> frozenset[str]` — read the file once at import, lowercased,
+  blanks stripped.
+- `contains_profanity(name) -> bool` — lowercase `name`; reject if the whole
+  string is in the set, or if any token (split on `_`/`-`) is in the set.
+  Exact-word/token match avoids false positives like `assassin`/`classic`
+  while catching `xX_fuck_Xx`. Multi-word stoplist phrases (with spaces) can
+  never match a username and are simply inert.
+- `UsernameError(StrEnum)` (or sentinel return) with members `invalid_format`,
+  `profane` so the endpoint maps to status codes.
+- `validate_username(name) -> UsernameError | None`.
+
+### `PATCH /users/me`
+- Body `UpdateUserRequest(BaseModel)`: `username: str`.
+- Auth via existing `get_current_user_address`.
+- Logic:
+  1. `validate_username` → `invalid_format` ⇒ **400** "Username must be 3–20
+     characters: letters, numbers, _ or -."
+  2. `profane` ⇒ **400** "Username contains inappropriate language."
+  3. If equal to the caller's current username ⇒ no-op success.
+  4. Uniqueness: another user holds it ⇒ **409** "Username already taken."
+  5. Assign, commit. `IntegrityError` on the unique constraint ⇒ **409**
+     (race backstop).
+- Returns the same dict shape as `GET /users/me`.
+
+## Frontend
+
+### Route `/profile`
+- `+page.server.ts`:
+  - `load`: redirect to `/auth` if no `session`; else `GET /users/me` with
+    Bearer; return `{ identity_address, username, created_at, last_login }`.
+  - action `update`: read `username` from form; `PATCH /users/me` with Bearer;
+    `!ok` ⇒ `fail(status, { error: detail })`; ok ⇒ `{ success: true, username }`.
+- `+page.svelte`: D2-retro UI reusing existing chrome components
+  (`InnerPanel`, `SectionTitle`, `OrnateButton`, …). Read-only identity address,
+  created_at, last_login + inline username edit form with a client-side regex
+  hint and server-side error display, via `use:enhance`.
+
+### Nav
+- Add a `Profile` tab in `+layout.svelte`, shown only when authenticated. Add a
+  minimal `+layout.server.ts` returning `{ isAuthenticated: !!cookies.get('session') }`.
+
+## Testing
+- Backend (TDD): `tests/test_users.py` — success; invalid regex (too short / bad
+  chars); profanity rejected (case-insensitive + token form); 409 conflict;
+  idempotent same-username; 401 unauthenticated; stoplist loads non-empty.
+- Frontend: no test harness exists in the repo; verify the `/profile` flow
+  manually on Docker.
+
+## Out of scope
+- The Python-2-style `except jwt.InvalidTokenError, KeyError:` at
+  `main.py:227` (parses on 3.14 but binds to `KeyError` instead of catching it).
+  Latent, currently harmless.

--- a/frontend/src/routes/+layout.server.ts
+++ b/frontend/src/routes/+layout.server.ts
@@ -1,0 +1,7 @@
+import type { LayoutServerLoad } from './$types';
+
+export const load: LayoutServerLoad = async ({ cookies }) => {
+	return {
+		isAuthenticated: !!cookies.get('session')
+	};
+};

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -9,7 +9,7 @@
 	import Hint from '$lib/components/chrome/Hint.svelte';
 	import { provideHints } from '$lib/hintsContext.svelte';
 
-	let { children } = $props();
+	let { children, data } = $props();
 
 	const hints = provideHints([
 		{ key: 'Esc', label: 'Back', tone: 'red' },
@@ -33,6 +33,9 @@
 	<Tabs>
 		<Tab href="/auth">Identity</Tab>
 		<Tab href="/rooms">Rooms</Tab>
+		{#if data?.isAuthenticated}
+			<Tab href="/profile">Profile</Tab>
+		{/if}
 		<Tab href="/about">About</Tab>
 	</Tabs>
 

--- a/frontend/src/routes/profile/+page.server.ts
+++ b/frontend/src/routes/profile/+page.server.ts
@@ -1,0 +1,78 @@
+import type { Actions, PageServerLoad } from './$types';
+import { env } from '$env/dynamic/public';
+import { env as privateEnv } from '$env/dynamic/private';
+import { fail, redirect } from '@sveltejs/kit';
+
+function backendBase(): string {
+	return privateEnv.BACKEND_INTERNAL_URL || env.PUBLIC_BACKEND_URL || 'http://localhost:8000';
+}
+
+interface Profile {
+	identity_address: string;
+	username: string;
+	created_at: string | null;
+	last_login: string | null;
+}
+
+export const load: PageServerLoad = async ({ cookies }) => {
+	const session = cookies.get('session');
+	if (!session) {
+		throw redirect(303, '/auth');
+	}
+
+	const res = await fetch(`${backendBase()}/users/me`, {
+		headers: { Authorization: `Bearer ${session}` }
+	});
+
+	if (!res.ok) {
+		// Stale/invalid session — send the user back to authenticate.
+		throw redirect(303, '/auth');
+	}
+
+	const data = (await res.json()) as Profile;
+	return {
+		profile: {
+			identity_address: data.identity_address,
+			username: data.username,
+			created_at: data.created_at,
+			last_login: data.last_login
+		}
+	};
+};
+
+export const actions: Actions = {
+	update: async ({ request, cookies }) => {
+		const session = cookies.get('session');
+		if (!session) return fail(401, { error: 'Not authenticated' });
+
+		const form = await request.formData();
+		const username = form.get('username');
+		if (typeof username !== 'string' || username.trim().length === 0) {
+			return fail(400, { error: 'Username is required.' });
+		}
+
+		try {
+			const res = await fetch(`${backendBase()}/users/me`, {
+				method: 'PATCH',
+				headers: {
+					'Content-Type': 'application/json',
+					Authorization: `Bearer ${session}`
+				},
+				body: JSON.stringify({ username: username.trim() })
+			});
+
+			if (!res.ok) {
+				const result = await res.json().catch(() => ({}));
+				return fail(res.status, {
+					error: result.detail || 'Failed to update username.',
+					username: username.trim()
+				});
+			}
+
+			const updated = await res.json();
+			return { success: true, username: updated.username };
+		} catch {
+			return fail(500, { error: 'Server error', username: username.trim() });
+		}
+	}
+};

--- a/frontend/src/routes/profile/+page.svelte
+++ b/frontend/src/routes/profile/+page.svelte
@@ -1,0 +1,303 @@
+<script lang="ts">
+	import { enhance } from '$app/forms';
+	import { invalidateAll } from '$app/navigation';
+	import InnerPanel from '$lib/components/chrome/InnerPanel.svelte';
+	import SectionTitle from '$lib/components/chrome/SectionTitle.svelte';
+	import OrnateButton from '$lib/components/chrome/OrnateButton.svelte';
+	import Sigil from '$lib/components/chrome/Sigil.svelte';
+	import SystemDialog from '$lib/components/chrome/SystemDialog.svelte';
+	import { getHintsState } from '$lib/hintsContext.svelte';
+	import type { PageProps } from './$types';
+
+	let { data, form }: PageProps = $props();
+
+	let username = $state(data.profile.username);
+	let saving = $state(false);
+	let savedAt = $state<string | null>(null);
+
+	// Client-side mirror of the backend rule: 3-20 chars, [a-zA-Z0-9_-].
+	const USERNAME_RE = /^[a-zA-Z0-9_-]{3,20}$/;
+	let clientValid = $derived(USERNAME_RE.test(username.trim()));
+	let dirty = $derived(username.trim() !== data.profile.username);
+	let serverError = $derived(form && 'error' in form ? form.error : '');
+	let errorOpen = $state(false);
+
+	$effect(() => {
+		errorOpen = !!serverError;
+	});
+
+	const hintsState = getHintsState();
+	$effect(() => {
+		hintsState?.set([{ key: 'Enter', label: 'Save Name', tone: 'gold' }]);
+	});
+
+	function fmtDate(iso: string | null): string {
+		if (!iso) return '—';
+		const d = new Date(iso);
+		return Number.isNaN(d.getTime()) ? iso : d.toLocaleString();
+	}
+</script>
+
+<svelte:head>
+	<title>PlayLink — Profile</title>
+</svelte:head>
+
+<div class="profile-page anim-content-in">
+	<InnerPanel title="Wanderer's Profile">
+		<div class="profile">
+			<div class="identity-head">
+				<div class="sigil-halo">
+					<Sigil address={data.profile.identity_address} size={88} />
+				</div>
+				<div class="identity">
+					<h2 class="username etched-gold">{data.profile.username}</h2>
+					<code class="address mono">{data.profile.identity_address}</code>
+				</div>
+			</div>
+
+			<span class="hairline-gold"></span>
+
+			<dl class="meta">
+				<div class="meta-row">
+					<dt>Bound Since</dt>
+					<dd class="mono">{fmtDate(data.profile.created_at)}</dd>
+				</div>
+				<div class="meta-row">
+					<dt>Last Seen</dt>
+					<dd class="mono">{fmtDate(data.profile.last_login)}</dd>
+				</div>
+			</dl>
+
+			<span class="hairline-gold"></span>
+
+			<div class="edit-zone">
+				<SectionTitle title="Chosen Name" size="small" tone="gold" />
+				<form
+					method="POST"
+					action="?/update"
+					class="edit-form"
+					use:enhance={() => {
+						saving = true;
+						return async ({ result, update }) => {
+							await update({ reset: false });
+							saving = false;
+							if (result.type === 'success') {
+								savedAt = new Date().toLocaleTimeString();
+								await invalidateAll();
+							}
+						};
+					}}
+				>
+					<input
+						name="username"
+						class="name-input mono"
+						bind:value={username}
+						maxlength="20"
+						autocomplete="off"
+						spellcheck="false"
+						aria-label="Username"
+					/>
+					<OrnateButton
+						variant="primary"
+						size="md"
+						type="submit"
+						loading={saving}
+						disabled={saving || !dirty || !clientValid}
+					>
+						{saving ? 'Saving…' : 'Save Name'}
+					</OrnateButton>
+				</form>
+
+				<p class="hint" class:bad={username.trim().length > 0 && !clientValid}>
+					3–20 characters · letters, numbers, <code>_</code> or <code>-</code>
+				</p>
+
+				{#if savedAt && !dirty && !serverError}
+					<p class="ok">Name saved ✓</p>
+				{/if}
+			</div>
+
+			{#if serverError}
+				<SystemDialog
+					bind:open={errorOpen}
+					title="Name Rejected"
+					tone="blood"
+					inline
+					closeable
+					onclose={() => (errorOpen = false)}
+				>
+					<p class="error-body">{serverError}</p>
+				</SystemDialog>
+			{/if}
+		</div>
+	</InnerPanel>
+</div>
+
+<style>
+	.profile-page {
+		max-width: 760px;
+		margin: 2rem auto;
+		padding: 0 1rem;
+	}
+
+	.profile {
+		display: flex;
+		flex-direction: column;
+	}
+
+	.etched-gold {
+		font-family: var(--font-display);
+		font-weight: normal;
+		color: var(--bone-bright);
+		text-shadow:
+			0 0 14px rgba(227, 188, 116, 0.16),
+			0 1px 0 rgba(0, 0, 0, 0.85);
+	}
+
+	.mono {
+		font-family: var(--font-mono);
+	}
+
+	.hairline-gold {
+		display: block;
+		height: 1px;
+		width: 100%;
+		background: var(--hair-gold);
+		border: 0;
+		margin: 1.25rem 0;
+	}
+
+	.identity-head {
+		display: flex;
+		gap: 1.4rem;
+		align-items: center;
+	}
+
+	.sigil-halo {
+		flex-shrink: 0;
+	}
+
+	.identity {
+		display: flex;
+		flex-direction: column;
+		gap: 0.5rem;
+		min-width: 0;
+		flex: 1;
+	}
+
+	.username {
+		margin: 0;
+		font-size: 1.9rem;
+		letter-spacing: var(--track-display);
+		text-transform: uppercase;
+		line-height: 1.05;
+		word-break: break-word;
+	}
+
+	.address {
+		display: inline-block;
+		font-size: 0.78rem;
+		color: var(--bone-muted);
+		letter-spacing: 0.04em;
+		word-break: break-all;
+	}
+
+	.meta {
+		margin: 0;
+		display: flex;
+		flex-direction: column;
+		gap: 0.7rem;
+	}
+
+	.meta-row {
+		display: flex;
+		justify-content: space-between;
+		gap: 1rem;
+		align-items: baseline;
+	}
+
+	.meta-row dt {
+		font-family: var(--font-display);
+		text-transform: uppercase;
+		letter-spacing: 0.08em;
+		font-size: 0.8rem;
+		color: var(--gold-muted);
+	}
+
+	.meta-row dd {
+		margin: 0;
+		font-size: 0.82rem;
+		color: var(--bone-muted);
+		text-align: right;
+	}
+
+	.edit-zone {
+		display: flex;
+		flex-direction: column;
+		gap: 0.7rem;
+	}
+
+	.edit-form {
+		display: flex;
+		gap: 0.8rem;
+		align-items: stretch;
+		flex-wrap: wrap;
+	}
+
+	.name-input {
+		flex: 1;
+		min-width: 200px;
+		background: var(--ink-well, rgba(0, 0, 0, 0.35));
+		border: 1px solid var(--hair-gold);
+		color: var(--bone-bright);
+		font-size: 1rem;
+		letter-spacing: 0.04em;
+		padding: 0.6rem 0.8rem;
+	}
+
+	.name-input:focus {
+		outline: none;
+		border-color: var(--gold-base);
+		box-shadow: 0 0 8px rgba(227, 188, 116, 0.25);
+	}
+
+	.hint {
+		margin: 0;
+		font-family: var(--font-display);
+		font-size: 0.8rem;
+		color: var(--bone-muted);
+		letter-spacing: 0.02em;
+	}
+
+	.hint code {
+		font-family: var(--font-mono);
+		color: var(--gold-muted);
+	}
+
+	.hint.bad {
+		color: var(--blood-bright);
+	}
+
+	.ok {
+		margin: 0;
+		font-family: var(--font-mono);
+		font-size: 0.82rem;
+		color: var(--pip-good);
+	}
+
+	.error-body {
+		margin: 0;
+		font-family: var(--font-mono);
+		font-size: 0.85rem;
+		color: var(--blood-bright);
+		line-height: 1.45;
+		word-break: break-word;
+	}
+
+	@media (max-width: 540px) {
+		.identity-head {
+			flex-direction: column;
+			align-items: flex-start;
+		}
+	}
+</style>

--- a/frontend/src/routes/profile/+page.svelte
+++ b/frontend/src/routes/profile/+page.svelte
@@ -20,11 +20,7 @@
 	let clientValid = $derived(USERNAME_RE.test(username.trim()));
 	let dirty = $derived(username.trim() !== data.profile.username);
 	let serverError = $derived(form && 'error' in form ? form.error : '');
-	let errorOpen = $state(false);
-
-	$effect(() => {
-		errorOpen = !!serverError;
-	});
+	let errorOpen = $derived(!!serverError);
 
 	const hintsState = getHintsState();
 	$effect(() => {


### PR DESCRIPTION
Closes #56.

Lets an authenticated user set a custom, unique username (replacing the auto-generated `user_<hex>`), validated against a vendored public profanity stoplist.

## Backend
- `usernames.py`: `^[a-zA-Z0-9_-]{3,20}$` format rule + profanity check. Exact whole-string and `_`/`-` token matching (catches `xX_fuck_Xx`, avoids false positives like `assassin`).
- `data/profanity_en.txt`: vendored LDNOOBW `en` list (source + git blob documented in the loader). Offline, version-pinned.
- `PATCH /users/me`: 400 invalid / 400 profane / 409 conflict; idempotent on your own name; `IntegrityError` race backstop. No DB migration (column already exists, unique+indexed).
- `tests/test_users.py`: 11 tests. Full suite 80 passed, ruff clean.

## Frontend
- `/profile` route: server `load` gated to `/auth` when unauthenticated; `update` action proxies `PATCH /users/me`.
- D2-retro page reusing existing chrome components, client-side regex hint, `use:enhance`, server-error dialog.
- Auth-gated **Profile** tab in the nav.

## Verification
- 8 signed end-to-end backend scenarios returned correct codes/messages.
- Browser smoke test on Docker: login → Profile tab → rename to `ShadowWolf_42` ("Name saved ✓") → `shit_lord` rejected with "Username contains inappropriate language."

Spec: `docs/superpowers/specs/2026-05-29-username-editing-design.md`
