### PR TITLE
fix(ui): modal scroll, room/chat layout, responsive polish (#72)

### DIFF
--- a/frontend/src/lib/components/MnemonicInput.svelte
+++ b/frontend/src/lib/components/MnemonicInput.svelte
@@ -244,4 +244,20 @@
 			gap: 0.5rem;
 		}
 	}
+
+	/* Very small phones: reclaim the wide left gutter and tighten cells so the
+	   word inputs stay legible at ~300px wide. */
+	@media (max-width: 360px) {
+		.word-slot {
+			min-height: 46px;
+			padding: 0 0.5rem 0 1.6rem;
+		}
+		.number {
+			left: 0.35rem;
+			font-size: 0.55rem;
+		}
+		input {
+			font-size: 0.82rem;
+		}
+	}
 </style>

--- a/frontend/src/lib/components/RoomEvent.svelte
+++ b/frontend/src/lib/components/RoomEvent.svelte
@@ -475,6 +475,10 @@
 		box-shadow:
 			var(--bevel-in),
 			inset 0 0 30px rgba(0, 0, 0, 0.25);
+		/* Cap the whole event area so a full lobby's RSVP list scrolls here
+		   instead of growing the panel and squeezing the chat out of view. */
+		max-height: clamp(180px, 32vh, 320px);
+		overflow-y: auto;
 	}
 
 	.trail-countdown {
@@ -671,6 +675,7 @@
 		display: flex;
 		justify-content: space-between;
 		align-items: center;
+		gap: 0.5rem;
 		padding: 0.4rem 0.55rem;
 		border-bottom: 1px solid var(--stone-5);
 		font-family: var(--font-display);
@@ -684,11 +689,17 @@
 	.roster-name {
 		color: var(--bone);
 		letter-spacing: var(--track-loose);
+		/* Truncate long usernames instead of stretching the row. */
+		min-width: 0;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
 	}
 
 	.roster-status {
 		font-size: 0.7rem;
 		letter-spacing: var(--track-loose);
+		flex-shrink: 0;
 	}
 
 	.roster-row[data-status='present'] .roster-status {

--- a/frontend/src/lib/components/chrome/InnerPanel.svelte
+++ b/frontend/src/lib/components/chrome/InnerPanel.svelte
@@ -80,6 +80,14 @@
 		overflow: hidden;
 	}
 
+	/* On very small phones the 8px margin plus the bronze ring leaves too little
+	   width for content — trim the margin to claw back ~8px each side. */
+	@media (max-width: 380px) {
+		.inner-panel {
+			margin: 4px;
+		}
+	}
+
 	/* Mid-grey stone fill with multi-octave fractal noise baked into a data URI.
 	   This is the "weathered stone" surface at the panel's center. */
 	.panel-stone {

--- a/frontend/src/lib/components/chrome/ListRow.svelte
+++ b/frontend/src/lib/components/chrome/ListRow.svelte
@@ -96,6 +96,13 @@
 		border-radius: 0;
 	}
 
+	/* Let every cell shrink below its content width so long values (e.g. room
+	   names) truncate via ellipsis instead of widening the track and forcing
+	   the whole row to overflow horizontally. */
+	.row > :global(*) {
+		min-width: 0;
+	}
+
 	/* Vertical etched separators between columns.
 	   Exclude .select-pip so the absolute-positioned indicator isn't reset to relative
 	   (which would push it into the first grid track and shift every cell). */

--- a/frontend/src/lib/components/chrome/PageFrame.svelte
+++ b/frontend/src/lib/components/chrome/PageFrame.svelte
@@ -118,6 +118,13 @@
 		overflow: hidden;
 	}
 
+	/* Reclaim horizontal space on very small phones. */
+	@media (max-width: 380px) {
+		.page-frame {
+			padding: 14px;
+		}
+	}
+
 	.frame-back {
 		position: absolute;
 		inset: 0;

--- a/frontend/src/lib/components/chrome/SystemDialog.svelte
+++ b/frontend/src/lib/components/chrome/SystemDialog.svelte
@@ -208,10 +208,28 @@
 		animation: sys-scale-in 200ms cubic-bezier(0.16, 1, 0.3, 1) both;
 	}
 
-	/* Modal variant: dialog inside overlay flexbox. */
+	/* Modal variant: dialog inside overlay flexbox.
+	   Capped to the viewport (overlay adds 1rem padding each side → 2rem) and
+	   laid out as a column so the body scrolls and the footer stays reachable
+	   no matter how tall the content gets. */
 	.sys-dialog.modal {
 		position: relative;
 		animation: sys-scale-in 200ms cubic-bezier(0.16, 1, 0.3, 1) both;
+		display: flex;
+		flex-direction: column;
+		max-height: calc(100dvh - 2rem);
+		overflow: hidden;
+	}
+
+	.sys-dialog.modal .title-bar,
+	.sys-dialog.modal .footer {
+		flex-shrink: 0;
+	}
+
+	.sys-dialog.modal .body {
+		flex: 1 1 auto;
+		min-height: 0;
+		overflow-y: auto;
 	}
 
 	.left-bar {

--- a/frontend/src/lib/styles/chrome.css
+++ b/frontend/src/lib/styles/chrome.css
@@ -268,14 +268,20 @@
 .anim-frame-in {
 	animation: fadeIn 0.55s ease-out 0ms both;
 }
+/* `backwards` (not `both`) so the staggered "from" state still applies during
+   the start delay, but the element rests at `transform: none` once the
+   animation finishes. A retained identity transform would otherwise make these
+   elements a containing block for `position: fixed`, breaking modal/toast
+   anchoring to the viewport. The end keyframe equals the resting state, so
+   there is no visual change. */
 .anim-panel-in {
-	animation: slideUp 0.5s cubic-bezier(0.16, 1, 0.3, 1) 200ms both;
+	animation: slideUp 0.5s cubic-bezier(0.16, 1, 0.3, 1) 200ms backwards;
 }
 .anim-content-in {
-	animation: slideUp 0.45s cubic-bezier(0.16, 1, 0.3, 1) 380ms both;
+	animation: slideUp 0.45s cubic-bezier(0.16, 1, 0.3, 1) 380ms backwards;
 }
 .anim-hints-in {
-	animation: slideUp 0.4s cubic-bezier(0.16, 1, 0.3, 1) 560ms both;
+	animation: slideUp 0.4s cubic-bezier(0.16, 1, 0.3, 1) 560ms backwards;
 }
 
 .torch-flicker {

--- a/frontend/src/routes/rooms/+page.svelte
+++ b/frontend/src/routes/rooms/+page.svelte
@@ -363,7 +363,7 @@
 								onclick={() => (selectedName = room.name)}
 							>
 								<span class="cell-name fw-700" class:is-member={member}>
-									{room.name}
+									<span class="name-text">{room.name}</span>
 									{#if member}
 										<span class="member-tag" aria-label="You are a member">JOINED</span>
 									{/if}
@@ -925,12 +925,23 @@
 	/* Cells */
 	.cell-name {
 		color: var(--bone-bright);
+		min-width: 0;
 		overflow: hidden;
-		text-overflow: ellipsis;
-		white-space: nowrap;
 		display: inline-flex;
 		align-items: center;
 		gap: 0.55rem;
+	}
+
+	/* The name itself truncates; the JOINED tag keeps its size. */
+	.cell-name .name-text {
+		min-width: 0;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
+	.cell-name .member-tag {
+		flex-shrink: 0;
 	}
 
 	.cell-name.is-member {

--- a/frontend/src/routes/rooms/[name]/+page.svelte
+++ b/frontend/src/routes/rooms/[name]/+page.svelte
@@ -327,15 +327,16 @@
 	.room-page {
 		display: grid;
 		grid-template-columns: 240px 1fr;
-		/* `minmax(0, 1fr)` row + a viewport-bounded height give the grid a definite
-		   height, so the flex chain inside can hand the chat exactly the leftover
-		   space (and scroll it) instead of growing the page. The subtracted ~20rem
-		   accounts for the fixed page chrome above/below (frame, brand, tabs, hint
-		   bar). */
+		/* A viewport-bounded height gives the grid a definite size, so the inner
+		   flex chain hands the chat the leftover space (and scrolls it) instead
+		   of growing the page. The ~18rem accounts for the real fixed chrome
+		   above (frame padding + brand + tabs ≈ 165px) and below (hint bar block
+		   + frame padding ≈ 114px) — measured, not guessed. `min-height` keeps a
+		   usable floor on very short viewports (the page scrolls below it). */
 		grid-template-rows: minmax(0, 1fr);
 		gap: 1rem;
 		min-height: 380px;
-		height: calc(100dvh - 10rem);
+		height: calc(100dvh - 18rem);
 		align-items: stretch;
 	}
 
@@ -569,6 +570,9 @@
 	.event-slot {
 		display: flex;
 		flex-direction: column;
+		/* Let the event panel shrink within the flex column so it can never
+		   steal the chat's space — the roster scrolls internally instead. */
+		min-height: 0;
 	}
 
 	/* --- Chat scroll area --- */


### PR DESCRIPTION
Closes #72.

Subagent-driven audit of every screen, then targeted fixes for the two reported bugs plus clear scaling breakage. No backend changes.

## P0 — reported bugs
**Create-room modal overflow.** The fixed overlay centered a dialog with no height cap, so on short viewports the Cancel/Create footer was pushed off-screen with no way to scroll. Root cause went deeper: `.page-main` kept an identity `transform` from its entrance animation (fill-mode `both`), which made it a containing block for `position:fixed` — so the overlay anchored to the tall page, not the viewport.
- `SystemDialog`: modal is now a flex column capped at `calc(100dvh - 2rem)` with a scrollable body and a non-shrinking footer.
- `chrome.css`: switched the transform-based entrance animations (`anim-panel-in/content-in/hints-in`) from `both` to `backwards`, so elements rest at `transform: none`. Fixed overlays/toasts anchor to the viewport again; entrance visuals unchanged.

**Room detail: chat squeezed out by a scheduled event + full roster.** The event panel and roster were unbounded and stole the chat's space; the room also hardcoded `height: calc(100dvh - 10rem)`, under-budgeting the real chrome (~18rem) so the grid overflowed.
- `RoomEvent`: event panel capped (`max-height: clamp(180px,32vh,320px)`, `overflow-y:auto`) so a full lobby scrolls within the event area; long usernames truncate.
- room `[name]`: `event-slot { min-height:0 }`; corrected the grid height budget to `calc(100dvh - 18rem)` (measured, with the comment explaining why).

## P1 — scaling breakage from the audit
- `MnemonicInput`: tightened cells/padding below 360px so the 12-word grid stays legible.
- `ListRow` + rooms `+page`: `min-width:0` on grid cells and an ellipsis-truncating name span — long room names no longer cause horizontal overflow.
- `InnerPanel` + `PageFrame`: trim margin/padding below 380px to reclaim width on small phones.

## Verification (Docker + Playwright)
Provisioned a full lobby (creator + 9 members, scheduled event, RSVPs) and measured layout at 600/800/900px heights and 320/360px widths:
- Modal: dialog within viewport, body scrolls, footer reachable.
- Room: event panel scrolls internally, chat + composer fully visible, hint bar visible, no page overflow (600px floor scrolls ~60px).
- Long room name truncates with 0 horizontal overflow at 360px; mnemonic 2-col with 0 overflow at 320px; auth/covenant no overflow at 320px.

Out of scope (deferred P2): shared breakpoint tokens, `prefers-reduced-motion`, safe-area insets, About-page tweaks, fluid font clamps.
