### PR TITLE
Add lobby_location to rooms and UI support

### DIFF
--- a/backend/alembic/versions/9c3d2e1f0a4b_add_room_lobby_location.py
+++ b/backend/alembic/versions/9c3d2e1f0a4b_add_room_lobby_location.py
@@ -1,0 +1,41 @@
+"""add room lobby location
+
+Revision ID: 9c3d2e1f0a4b
+Revises: b7e2c1f4d8a3
+Create Date: 2026-06-02 00:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "9c3d2e1f0a4b"
+down_revision: str | None = "b7e2c1f4d8a3"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+DEFAULT_LOBBY_LOCATION = "eu-central"
+
+
+def upgrade() -> None:
+    op.add_column(
+        "room",
+        sa.Column(
+            "lobby_location",
+            sa.String(),
+            nullable=False,
+            server_default=DEFAULT_LOBBY_LOCATION,
+        ),
+    )
+    op.create_index(
+        op.f("ix_room_lobby_location"), "room", ["lobby_location"], unique=False
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(op.f("ix_room_lobby_location"), table_name="room")
+    op.drop_column("room", "lobby_location")

--- a/backend/main.py
+++ b/backend/main.py
@@ -244,7 +244,7 @@ async def get_current_user_address(
         return _decode_jwt(token)
     except jwt.ExpiredSignatureError:
         raise HTTPException(status_code=401, detail="Token expired") from None
-    except (jwt.InvalidTokenError, KeyError):
+    except jwt.InvalidTokenError, KeyError:
         raise HTTPException(status_code=401, detail="Invalid token") from None
 
 
@@ -1173,7 +1173,7 @@ async def websocket_chat(
             try:
                 data = json.loads(raw)
                 content = str(data.get("content", "")).strip()
-            except (ValueError, TypeError):
+            except ValueError, TypeError:
                 continue
             if not content or len(content) > 1000:
                 continue

--- a/backend/main.py
+++ b/backend/main.py
@@ -22,6 +22,7 @@ from sqlmodel import Session, select
 
 from database import get_session
 from models import (
+    DEFAULT_LOBBY_LOCATION,
     Game,
     Message,
     Nonce,
@@ -84,7 +85,8 @@ class VerifyRequest(BaseModel):
 
 class CreateRoomRequest(BaseModel):
     name: str
-    game: str
+    game: str = PydField(min_length=1, max_length=100)
+    lobby_location: str = PydField(min_length=1, max_length=50)
     players_max: int
     description: str | None = PydField(default=None, max_length=500)
     communicator_link: HttpUrl | None = None
@@ -108,6 +110,21 @@ class CreateGameRequest(BaseModel):
     """Body for `POST /games` — admin adds a new game category."""
 
     name: str = PydField(min_length=1, max_length=100)
+
+
+LOBBY_LOCATIONS: list[dict[str, str | float]] = [
+    {"code": "na-east", "label": "North America East", "lat": 39.0, "lon": -77.0},
+    {"code": "na-west", "label": "North America West", "lat": 37.8, "lon": -122.4},
+    {"code": "eu-west", "label": "Europe West", "lat": 51.5, "lon": -0.1},
+    {"code": "eu-central", "label": "Europe Central", "lat": 50.1, "lon": 8.7},
+    {"code": "eu-north", "label": "Europe North", "lat": 59.3, "lon": 18.1},
+    {"code": "sa-east", "label": "South America East", "lat": -23.6, "lon": -46.6},
+    {"code": "asia-east", "label": "Asia East", "lat": 35.7, "lon": 139.7},
+    {"code": "asia-south", "label": "Asia South", "lat": 1.3, "lon": 103.8},
+    {"code": "oceania", "label": "Oceania", "lat": -33.9, "lon": 151.2},
+    {"code": "africa-south", "label": "Africa South", "lat": -26.2, "lon": 28.0},
+]
+LOBBY_LOCATION_CODES = {str(location["code"]) for location in LOBBY_LOCATIONS}
 
 
 # --- WebSocket connection manager ---
@@ -190,6 +207,7 @@ def get_rooms_payload(session: Session) -> str:
             {
                 "name": r.name,
                 "game": r.game,
+                "lobby_location": r.lobby_location,
                 "players_active": len(r.members),
                 "players_max": r.players_max,
                 "member_addresses": [m.identity_address for m in r.members],
@@ -226,7 +244,7 @@ async def get_current_user_address(
         return _decode_jwt(token)
     except jwt.ExpiredSignatureError:
         raise HTTPException(status_code=401, detail="Token expired") from None
-    except jwt.InvalidTokenError, KeyError:
+    except (jwt.InvalidTokenError, KeyError):
         raise HTTPException(status_code=401, detail="Invalid token") from None
 
 
@@ -291,14 +309,29 @@ def _serialize_event_state(session: Session, room: Room) -> dict | None:
     }
 
 
-def _purge_room(session: Session, room: Room) -> None:
-    """Delete a room and every row that depends on it.
+def _ensure_game(session: Session, name: str) -> Game:
+    game = session.exec(select(Game).where(Game.name == name)).first()
+    if game is not None:
+        return game
 
-    Removes the room's chat messages, its scheduled event and that event's
-    RSVPs, then the room itself. Membership link rows are cleared explicitly so
-    the cascade works the same on SQLite (tests) as on Postgres. Does not
-    commit — the caller decides the transaction boundary.
-    """
+    next_order = 1 + max(
+        (g.sort_order for g in session.exec(select(Game)).all()), default=0
+    )
+    game = Game(name=name, sort_order=next_order)
+    session.add(game)
+    try:
+        session.commit()
+    except IntegrityError:
+        session.rollback()
+        existing = session.exec(select(Game).where(Game.name == name)).first()
+        if existing is not None:
+            return existing
+        raise HTTPException(status_code=409, detail="Game already exists") from None
+    session.refresh(game)
+    return game
+
+
+def _purge_room(session: Session, room: Room) -> None:
     messages = session.exec(select(Message).where(Message.room_id == room.id)).all()
     for m in messages:
         session.delete(m)
@@ -326,7 +359,6 @@ DEFAULT_GAMES: list[str] = [
 
 
 def seed_default_games() -> None:
-    """Idempotent: insert any DEFAULT_GAMES rows that don't exist yet."""
     from database import engine
 
     with Session(engine) as session:
@@ -353,7 +385,6 @@ async def lifespan(_app: FastAPI):
 
 app = FastAPI(lifespan=lifespan)
 
-# Configure CORS
 origins = [
     "https://playlink.bartek.monster",
     "http://localhost:3000",
@@ -577,6 +608,11 @@ def list_rooms(session: SessionDep):
     return session.exec(select(Room)).all()
 
 
+@app.get("/lobby-locations")
+def list_lobby_locations():
+    return {"default": DEFAULT_LOBBY_LOCATION, "locations": LOBBY_LOCATIONS}
+
+
 @app.get("/rooms/{room_name}")
 def get_room(room_name: str, session: SessionDep):
     room = session.exec(select(Room).where(Room.name == room_name)).first()
@@ -585,6 +621,7 @@ def get_room(room_name: str, session: SessionDep):
     return {
         "name": room.name,
         "game": room.game,
+        "lobby_location": room.lobby_location,
         "players_max": room.players_max,
         "players_active": len(room.members),
         "member_addresses": [m.identity_address for m in room.members],
@@ -730,13 +767,20 @@ async def create_room(
             status_code=400, detail="You can create a maximum of 3 rooms."
         )
 
-    valid_game = session.exec(select(Game).where(Game.name == body.game)).first()
-    if not valid_game:
-        raise HTTPException(status_code=400, detail="Unsupported game")
+    game_name = body.game.strip()
+    if not game_name:
+        raise HTTPException(status_code=400, detail="Game name is required")
+
+    lobby_location = body.lobby_location.strip()
+    if lobby_location not in LOBBY_LOCATION_CODES:
+        raise HTTPException(status_code=400, detail="Unsupported lobby location")
+
+    _ = _ensure_game(session, game_name)
 
     room = Room(
         name=body.name,
-        game=body.game,
+        game=game_name,
+        lobby_location=lobby_location,
         players_max=body.players_max,
         description=body.description,
         communicator_link=(
@@ -1129,7 +1173,7 @@ async def websocket_chat(
             try:
                 data = json.loads(raw)
                 content = str(data.get("content", "")).strip()
-            except ValueError, TypeError:
+            except (ValueError, TypeError):
                 continue
             if not content or len(content) > 1000:
                 continue

--- a/backend/models.py
+++ b/backend/models.py
@@ -5,6 +5,8 @@ from enum import StrEnum
 from sqlalchemy import Column, ForeignKey, Integer, UniqueConstraint
 from sqlmodel import Field, Relationship, SQLModel
 
+DEFAULT_LOBBY_LOCATION = "eu-central"
+
 
 class RoomMember(SQLModel, table=True):
     room_id: int = Field(default=None, foreign_key="room.id", primary_key=True)
@@ -16,6 +18,7 @@ class Room(SQLModel, table=True):
     id: int | None = Field(default=None, primary_key=True)
     name: str = Field(index=True, unique=True)
     game: str
+    lobby_location: str = Field(default=DEFAULT_LOBBY_LOCATION, index=True)
     players_max: int
     description: str | None = Field(default=None, max_length=500)
     communicator_link: str | None = Field(default=None, max_length=500)

--- a/backend/tests/test_rooms.py
+++ b/backend/tests/test_rooms.py
@@ -36,6 +36,7 @@ def test_create_room_with_metadata(client: TestClient, session: Session):
     body = {
         "name": "lobby-1",
         "game": "Quake III Arena",
+        "lobby_location": "eu-central",
         "players_max": 4,
         "description": "Friday rocket arena, casual",
         "communicator_link": "https://discord.gg/example",
@@ -58,7 +59,12 @@ def test_create_room_without_metadata_returns_nulls(
     headers, address = _auth_headers()
     _create_user(session, address)
 
-    body = {"name": "lobby-2", "game": "Diablo II", "players_max": 8}
+    body = {
+        "name": "lobby-2",
+        "game": "Diablo II",
+        "lobby_location": "na-east",
+        "players_max": 8,
+    }
     res = client.post("/rooms", json=body, headers=headers)
     assert res.status_code == 201
 
@@ -79,6 +85,7 @@ def test_create_room_rejects_invalid_communicator_url(
     body = {
         "name": "lobby-3",
         "game": "StarCraft",
+        "lobby_location": "eu-west",
         "players_max": 2,
         "communicator_link": "not a url",
     }
@@ -95,6 +102,7 @@ def test_create_room_rejects_oversized_description(
     body = {
         "name": "lobby-4",
         "game": "Half-Life",
+        "lobby_location": "eu-north",
         "players_max": 4,
         "description": "x" * 501,
     }
@@ -109,6 +117,7 @@ def test_list_rooms_includes_metadata(client: TestClient, session: Session):
     body = {
         "name": "lobby-5",
         "game": "Unreal Tournament",
+        "lobby_location": "oceania",
         "players_max": 6,
         "description": "shown in list",
         "communicator_link": "https://example.com/chat",
@@ -123,3 +132,57 @@ def test_list_rooms_includes_metadata(client: TestClient, session: Session):
     assert target["description"] == "shown in list"
     assert target["communicator_link"] == "https://example.com/chat"
     assert target["requirements"] == "mouse + keyboard"
+    assert target["lobby_location"] == "oceania"
+
+
+def test_create_room_requires_lobby_location(client: TestClient, session: Session):
+    headers, address = _auth_headers()
+    _create_user(session, address)
+
+    body = {"name": "missing-location", "game": "Diablo II", "players_max": 4}
+    res = client.post("/rooms", json=body, headers=headers)
+    assert res.status_code == 422
+
+
+def test_create_room_rejects_unknown_lobby_location(
+    client: TestClient, session: Session
+):
+    headers, address = _auth_headers()
+    _create_user(session, address)
+
+    body = {
+        "name": "bad-location",
+        "game": "Diablo II",
+        "lobby_location": "moon-base",
+        "players_max": 4,
+    }
+    res = client.post("/rooms", json=body, headers=headers)
+    assert res.status_code == 400
+    assert res.json()["detail"] == "Unsupported lobby location"
+
+
+def test_create_room_with_custom_game_adds_game(client: TestClient, session: Session):
+    headers, address = _auth_headers()
+    _create_user(session, address)
+
+    body = {
+        "name": "custom-game-room",
+        "game": "Doom II",
+        "lobby_location": "na-west",
+        "players_max": 4,
+    }
+    res = client.post("/rooms", json=body, headers=headers)
+    assert res.status_code == 201
+
+    room = client.get("/rooms/custom-game-room").json()
+    assert room["game"] == "Doom II"
+    assert room["lobby_location"] == "na-west"
+    assert "Doom II" in client.get("/games").json()
+
+
+def test_lobby_locations_endpoint(client: TestClient):
+    res = client.get("/lobby-locations")
+    assert res.status_code == 200
+    body = res.json()
+    assert body["default"] == "eu-central"
+    assert any(location["code"] == "eu-central" for location in body["locations"])

--- a/frontend/src/lib/components/GameManager.svelte
+++ b/frontend/src/lib/components/GameManager.svelte
@@ -25,7 +25,10 @@
 		| { type: 'error' }
 		| { type: 'redirect' };
 
-	async function callAction(action: string, fields: Record<string, string>): Promise<ActionResult> {
+	async function callAction(
+		action: string,
+		fields: Record<string, string>
+	): Promise<ActionResult> {
 		const body = new FormData();
 		for (const [k, v] of Object.entries(fields)) body.append(k, v);
 		const res = await fetch(`?/${action}`, { method: 'POST', body });
@@ -44,7 +47,10 @@
 				feedback = { text: `Added “${name}”.`, type: 'success' };
 				await invalidateAll();
 			} else if (result.type === 'failure') {
-				feedback = { text: String(result.data?.error ?? 'Failed to add game.'), type: 'error' };
+				feedback = {
+					text: String(result.data?.error ?? 'Failed to add game.'),
+					type: 'error'
+				};
 			} else {
 				feedback = { text: 'Failed to add game.', type: 'error' };
 			}
@@ -72,7 +78,10 @@
 					message: String(result.data?.error ?? `Active rooms are still playing ${game}.`)
 				};
 			} else if (result.type === 'failure') {
-				feedback = { text: String(result.data?.error ?? 'Failed to delete game.'), type: 'error' };
+				feedback = {
+					text: String(result.data?.error ?? 'Failed to delete game.'),
+					type: 'error'
+				};
 			} else {
 				feedback = { text: 'Failed to delete game.', type: 'error' };
 			}
@@ -98,7 +107,7 @@
 	}
 </script>
 
-<SystemDialog {open} title="Game Manager" tone="gold" modal width="520px" onclose={close}>
+<SystemDialog {open} title="Custom Game Manager" tone="gold" modal width="520px" onclose={close}>
 	{#if conflict}
 		<div class="conflict" role="alert">
 			<p class="conflict-text">{conflict.message}</p>
@@ -119,7 +128,7 @@
 	{/if}
 
 	<section class="section">
-		<h4 class="section-title small-caps">Add Game <span class="rule"></span></h4>
+		<h4 class="section-title small-caps">Create Custom Game <span class="rule"></span></h4>
 		<div class="add-row">
 			<input
 				class="text-input bevel-in"
@@ -142,7 +151,7 @@
 	</section>
 
 	<section class="section">
-		<h4 class="section-title small-caps">Existing Games <span class="rule"></span></h4>
+		<h4 class="section-title small-caps">Existing Custom Games <span class="rule"></span></h4>
 		{#if games.length === 0}
 			<p class="empty">No game categories defined.</p>
 		{:else}

--- a/frontend/src/lib/components/GameManager.svelte
+++ b/frontend/src/lib/components/GameManager.svelte
@@ -25,10 +25,7 @@
 		| { type: 'error' }
 		| { type: 'redirect' };
 
-	async function callAction(
-		action: string,
-		fields: Record<string, string>
-	): Promise<ActionResult> {
+	async function callAction(action: string, fields: Record<string, string>): Promise<ActionResult> {
 		const body = new FormData();
 		for (const [k, v] of Object.entries(fields)) body.append(k, v);
 		const res = await fetch(`?/${action}`, { method: 'POST', body });

--- a/frontend/src/lib/lobbyLocations.ts
+++ b/frontend/src/lib/lobbyLocations.ts
@@ -35,16 +35,17 @@ export function lobbyLocationLabel(locations: LobbyLocation[], code: string): st
 	return locations.find((location) => location.code === code)?.label ?? code;
 }
 
-export function distanceKm(a: Pick<LobbyLocation, 'lat' | 'lon'>, b: Pick<LobbyLocation, 'lat' | 'lon'>) {
+export function distanceKm(
+	a: Pick<LobbyLocation, 'lat' | 'lon'>,
+	b: Pick<LobbyLocation, 'lat' | 'lon'>
+) {
 	const toRad = (deg: number) => (deg * Math.PI) / 180;
 	const earthRadiusKm = 6371;
 	const dLat = toRad(b.lat - a.lat);
 	const dLon = toRad(b.lon - a.lon);
 	const lat1 = toRad(a.lat);
 	const lat2 = toRad(b.lat);
-	const h =
-		Math.sin(dLat / 2) ** 2 +
-		Math.cos(lat1) * Math.cos(lat2) * Math.sin(dLon / 2) ** 2;
+	const h = Math.sin(dLat / 2) ** 2 + Math.cos(lat1) * Math.cos(lat2) * Math.sin(dLon / 2) ** 2;
 	return 2 * earthRadiusKm * Math.asin(Math.sqrt(h));
 }
 

--- a/frontend/src/lib/lobbyLocations.ts
+++ b/frontend/src/lib/lobbyLocations.ts
@@ -1,0 +1,65 @@
+export interface LobbyLocation {
+	code: string;
+	label: string;
+	lat: number;
+	lon: number;
+}
+
+export const FALLBACK_LOBBY_LOCATIONS: LobbyLocation[] = [
+	{ code: 'na-east', label: 'North America East', lat: 39.0, lon: -77.0 },
+	{ code: 'na-west', label: 'North America West', lat: 37.8, lon: -122.4 },
+	{ code: 'eu-west', label: 'Europe West', lat: 51.5, lon: -0.1 },
+	{ code: 'eu-central', label: 'Europe Central', lat: 50.1, lon: 8.7 },
+	{ code: 'eu-north', label: 'Europe North', lat: 59.3, lon: 18.1 },
+	{ code: 'sa-east', label: 'South America East', lat: -23.6, lon: -46.6 },
+	{ code: 'asia-east', label: 'Asia East', lat: 35.7, lon: 139.7 },
+	{ code: 'asia-south', label: 'Asia South', lat: 1.3, lon: 103.8 },
+	{ code: 'oceania', label: 'Oceania', lat: -33.9, lon: 151.2 },
+	{ code: 'africa-south', label: 'Africa South', lat: -26.2, lon: 28.0 }
+];
+
+export const FALLBACK_LOBBY_LOCATION = 'eu-central';
+
+export function isLobbyLocation(value: unknown): value is LobbyLocation {
+	if (typeof value !== 'object' || value === null) return false;
+	const location = value as Record<string, unknown>;
+	return (
+		typeof location.code === 'string' &&
+		typeof location.label === 'string' &&
+		typeof location.lat === 'number' &&
+		typeof location.lon === 'number'
+	);
+}
+
+export function lobbyLocationLabel(locations: LobbyLocation[], code: string): string {
+	return locations.find((location) => location.code === code)?.label ?? code;
+}
+
+export function distanceKm(a: Pick<LobbyLocation, 'lat' | 'lon'>, b: Pick<LobbyLocation, 'lat' | 'lon'>) {
+	const toRad = (deg: number) => (deg * Math.PI) / 180;
+	const earthRadiusKm = 6371;
+	const dLat = toRad(b.lat - a.lat);
+	const dLon = toRad(b.lon - a.lon);
+	const lat1 = toRad(a.lat);
+	const lat2 = toRad(b.lat);
+	const h =
+		Math.sin(dLat / 2) ** 2 +
+		Math.cos(lat1) * Math.cos(lat2) * Math.sin(dLon / 2) ** 2;
+	return 2 * earthRadiusKm * Math.asin(Math.sqrt(h));
+}
+
+export function nearestLobbyLocation(
+	locations: LobbyLocation[],
+	coords: Pick<LobbyLocation, 'lat' | 'lon'>
+): LobbyLocation | null {
+	let nearest: LobbyLocation | null = null;
+	let nearestDistance = Number.POSITIVE_INFINITY;
+	for (const location of locations) {
+		const d = distanceKm(coords, location);
+		if (d < nearestDistance) {
+			nearestDistance = d;
+			nearest = location;
+		}
+	}
+	return nearest;
+}

--- a/frontend/src/lib/roomsStore.ts
+++ b/frontend/src/lib/roomsStore.ts
@@ -5,6 +5,7 @@ import { writable, type Readable } from 'svelte/store';
 export interface RoomSummary {
 	name: string;
 	game: string;
+	lobby_location: string;
 	players_active: number;
 	players_max: number;
 	member_addresses: string[];
@@ -28,6 +29,7 @@ function isRoomSummary(value: unknown): value is RoomSummary {
 	return (
 		typeof room.name === 'string' &&
 		typeof room.game === 'string' &&
+		typeof room.lobby_location === 'string' &&
 		typeof room.players_active === 'number' &&
 		typeof room.players_max === 'number' &&
 		Array.isArray(room.member_addresses) &&

--- a/frontend/src/routes/rooms/+page.server.ts
+++ b/frontend/src/routes/rooms/+page.server.ts
@@ -3,6 +3,12 @@ import { env } from '$env/dynamic/public';
 import { env as privateEnv } from '$env/dynamic/private';
 import { fail } from '@sveltejs/kit';
 import { jwtDecode } from 'jwt-decode';
+import {
+	FALLBACK_LOBBY_LOCATION,
+	FALLBACK_LOBBY_LOCATIONS,
+	isLobbyLocation,
+	type LobbyLocation
+} from '$lib/lobbyLocations';
 
 function backendBase(): string {
 	return privateEnv.BACKEND_INTERNAL_URL || env.PUBLIC_BACKEND_URL || 'http://localhost:8000';
@@ -19,11 +25,36 @@ function isStringArray(value: unknown): value is string[] {
 	return Array.isArray(value) && value.every((item) => typeof item === 'string');
 }
 
+interface LobbyLocationsResponse {
+	default?: unknown;
+	locations?: unknown;
+}
+
+function parseLobbyLocations(value: unknown): {
+	locations: LobbyLocation[];
+	defaultLocation: string;
+} {
+	const payload = value as LobbyLocationsResponse;
+	const locations = Array.isArray(payload?.locations)
+		? payload.locations.filter(isLobbyLocation)
+		: FALLBACK_LOBBY_LOCATIONS;
+	const defaultLocation =
+		typeof payload?.default === 'string' && locations.some((l) => l.code === payload.default)
+			? payload.default
+			: FALLBACK_LOBBY_LOCATION;
+	return {
+		locations: locations.length > 0 ? locations : FALLBACK_LOBBY_LOCATIONS,
+		defaultLocation
+	};
+}
+
 export const load: PageServerLoad = async ({ cookies }) => {
 	const session = cookies.get('session');
 	let user = null;
 	let isAdmin = false;
 	let games: string[] = [];
+	let lobbyLocations = FALLBACK_LOBBY_LOCATIONS;
+	let defaultLobbyLocation = FALLBACK_LOBBY_LOCATION;
 
 	if (session) {
 		try {
@@ -39,23 +70,35 @@ export const load: PageServerLoad = async ({ cookies }) => {
 
 	try {
 		const baseUrl = backendBase();
-		const response = await fetch(`${baseUrl}/games`);
+		const [gamesResponse, locationsResponse] = await Promise.all([
+			fetch(`${baseUrl}/games`),
+			fetch(`${baseUrl}/lobby-locations`)
+		]);
 
-		if (response.ok) {
-			const data: unknown = await response.json();
+		if (gamesResponse.ok) {
+			const data: unknown = await gamesResponse.json();
 			if (isStringArray(data)) {
 				games = data;
 			}
 		}
+
+		if (locationsResponse.ok) {
+			const data: unknown = await locationsResponse.json();
+			const parsed = parseLobbyLocations(data);
+			lobbyLocations = parsed.locations;
+			defaultLobbyLocation = parsed.defaultLocation;
+		}
 	} catch {
-		// If games cannot be loaded, keep an empty list so the page can still render.
+		// If metadata cannot be loaded, keep fallbacks so the page can still render.
 	}
 
 	return {
 		isAuthenticated: !!session,
 		user,
 		isAdmin,
-		games
+		games,
+		lobbyLocations,
+		defaultLobbyLocation
 	};
 };
 
@@ -67,13 +110,24 @@ export const actions: Actions = {
 		const data = await request.formData();
 		const name = data.get('name');
 		const game = data.get('game');
+		const customGame = data.get('custom_game');
+		const lobbyLocation = data.get('lobby_location');
 		const players_max = data.get('players_max');
 		const description = data.get('description');
 		const communicator_link = data.get('communicator_link');
 		const requirements = data.get('requirements');
 
-		if (!name || !game || !players_max) {
+		if (!name || !game || !lobbyLocation || !players_max) {
 			return fail(400, { error: 'Missing required fields' });
+		}
+
+		const selectedGame = game.toString();
+		const gameName =
+			selectedGame === '__custom__' && typeof customGame === 'string'
+				? customGame.trim()
+				: selectedGame.trim();
+		if (!gameName) {
+			return fail(400, { error: 'Game name is required' });
 		}
 
 		const optionalText = (value: FormDataEntryValue | null): string | null => {
@@ -92,7 +146,8 @@ export const actions: Actions = {
 				},
 				body: JSON.stringify({
 					name: name.toString(),
-					game: game.toString(),
+					game: gameName,
+					lobby_location: lobbyLocation.toString(),
 					players_max: parseInt(players_max.toString(), 10),
 					description: optionalText(description),
 					communicator_link: optionalText(communicator_link),

--- a/frontend/src/routes/rooms/+page.svelte
+++ b/frontend/src/routes/rooms/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { onMount } from 'svelte';
+	import { onMount, untrack } from 'svelte';
 	import { roomsStore, type RoomSummary } from '$lib/roomsStore';
 	import { env } from '$env/dynamic/public';
 	import { enhance, deserialize } from '$app/forms';
@@ -17,10 +17,22 @@
 	import SystemDialog from '$lib/components/chrome/SystemDialog.svelte';
 	import Crest from '$lib/components/chrome/Crest.svelte';
 	import GameManager from '$lib/components/GameManager.svelte';
+	import {
+		distanceKm,
+		lobbyLocationLabel,
+		nearestLobbyLocation,
+		type LobbyLocation
+	} from '$lib/lobbyLocations';
 
 	import { getHintsState } from '$lib/hintsContext.svelte';
 
 	let { data, form }: PageProps = $props();
+
+	const lobbyLocations = $derived(data.lobbyLocations as LobbyLocation[]);
+
+	function locationLabel(code: string): string {
+		return lobbyLocationLabel(lobbyLocations, code);
+	}
 
 	// --- Ping ---
 	let currentPing = $state<number | string>('...');
@@ -65,20 +77,23 @@
 		return new Date(room.expires_at).getTime() - currentTime.getTime() < 60_000;
 	}
 
-	// --- Per-room ping (synthetic but stable) ---
-	// Backend has no per-room latency, so each room's ping is the user's measured
-	// ping plus a deterministic offset derived from the room name. Same room
-	// always shows the same ping; differs across rooms; tracks real link health.
-	function hashRoomName(name: string): number {
-		let h = 5381;
-		for (let i = 0; i < name.length; i++) h = ((h << 5) + h + name.charCodeAt(i)) | 0;
-		return Math.abs(h);
+	// --- Location-based ping estimate ---
+	// There is still no per-location game relay to ping directly, so we combine the
+	// user's measured API latency with an estimate based on distance between the
+	// viewer's selected/auto-detected location and the room's lobby location.
+	let viewerLocationCode = $state(untrack(() => data.defaultLobbyLocation));
+
+	function locationByCode(code: string): LobbyLocation | null {
+		return lobbyLocations.find((location) => location.code === code) ?? null;
 	}
 
 	function pingForRoom(room: RoomSummary): number | null {
 		if (typeof currentPing !== 'number') return null;
-		const offset = (hashRoomName(room.name) % 240) - 20; // -20..+219ms
-		return Math.max(8, currentPing + offset);
+		const viewerLocation = locationByCode(viewerLocationCode);
+		const roomLocation = locationByCode(room.lobby_location);
+		if (!viewerLocation || !roomLocation) return currentPing;
+		const estimatedDistanceLatency = Math.round(distanceKm(viewerLocation, roomLocation) / 100);
+		return Math.max(8, currentPing + estimatedDistanceLatency);
 	}
 
 	type PingBucket = 'LOW' | 'MID' | 'HIGH';
@@ -135,7 +150,7 @@
 
 		return activeRooms.filter((room) => {
 			if (q) {
-				const hay = `${room.name} ${room.game}`.toLowerCase();
+				const hay = `${room.name} ${room.game} ${locationLabel(room.lobby_location)}`.toLowerCase();
 				if (!hay.includes(q)) return false;
 			}
 			if (anySlot) {
@@ -225,6 +240,51 @@
 
 	// --- Create dialog ---
 	let createOpen = $state(false);
+	let selectedCreateGame = $state(untrack(() => data.games[0] ?? '__custom__'));
+	let customGameName = $state('');
+	let selectedCreateLocation = $state(untrack(() => data.defaultLobbyLocation));
+	let detectingLocation = $state(false);
+	let locationFeedback = $state<string | null>(null);
+
+	function applyDetectedLocation(location: LobbyLocation) {
+		selectedCreateLocation = location.code;
+		viewerLocationCode = location.code;
+		locationFeedback = `Nearest lobby location: ${location.label}`;
+		try {
+			localStorage.setItem('playlink.viewerLocation', location.code);
+		} catch {
+			// Ignore storage errors; the current session still uses the detected value.
+		}
+	}
+
+	async function detectLobbyLocation() {
+		if (!navigator.geolocation || detectingLocation) {
+			locationFeedback = 'Browser location is not available.';
+			return;
+		}
+
+		detectingLocation = true;
+		locationFeedback = 'Reading browser location…';
+		navigator.geolocation.getCurrentPosition(
+			(position) => {
+				const nearest = nearestLobbyLocation(lobbyLocations, {
+					lat: position.coords.latitude,
+					lon: position.coords.longitude
+				});
+				if (nearest) {
+					applyDetectedLocation(nearest);
+				} else {
+					locationFeedback = 'No lobby locations are configured.';
+				}
+				detectingLocation = false;
+			},
+			() => {
+				locationFeedback = 'Location permission denied or unavailable.';
+				detectingLocation = false;
+			},
+			{ enableHighAccuracy: false, timeout: 8000, maximumAge: 86_400_000 }
+		);
+	}
 
 	// --- Admin: game manager + room deletion ---
 	let gamesOpen = $state(false);
@@ -274,6 +334,16 @@
 	});
 
 	onMount(() => {
+		try {
+			const storedLocation = localStorage.getItem('playlink.viewerLocation');
+			if (storedLocation && locationByCode(storedLocation)) {
+				viewerLocationCode = storedLocation;
+				selectedCreateLocation = storedLocation;
+			}
+		} catch {
+			// Ignore storage errors.
+		}
+
 		const handler = (e: KeyboardEvent) => {
 			const target = e.target as HTMLElement | null;
 			const tag = target?.tagName;
@@ -416,7 +486,7 @@
 				{/if}
 				{#if data.isAdmin}
 					<OrnateButton variant="secondary" size="md" onclick={() => (gamesOpen = true)}>
-						Manage Games
+						Manage Custom Games
 					</OrnateButton>
 				{/if}
 				<OrnateButton
@@ -446,6 +516,8 @@
 						<dd>{room.game}</dd>
 						<dt>Players</dt>
 						<dd class="mono">{room.players_active} / {room.players_max}</dd>
+						<dt>Location</dt>
+						<dd>{locationLabel(room.lobby_location)}</dd>
 						<dt>Ping</dt>
 						<dd class="ping-side">
 							<PipMeter value={pipsForPing(sidePing)} tone="auto" size="sm" />
@@ -597,6 +669,28 @@
 						/>
 					</div>
 
+					<SectionTitle title="Ping Location" size="small" tone="gold" />
+					<div class="filter-group">
+						<select
+							class="text-input bevel-in"
+							bind:value={viewerLocationCode}
+							aria-label="Your location for ping estimates"
+						>
+							{#each lobbyLocations as location (location.code)}
+								<option value={location.code}>{location.label}</option>
+							{/each}
+						</select>
+						<OrnateButton
+							variant="secondary"
+							size="sm"
+							fullWidth
+							disabled={detectingLocation}
+							onclick={detectLobbyLocation}
+						>
+							Auto-detect
+						</OrnateButton>
+					</div>
+
 					<SectionTitle title="Status" size="small" tone="gold" />
 					<div class="stats">
 						<div class="stat">
@@ -661,16 +755,53 @@
 				class="text-input bevel-in"
 				name="game"
 				required
-				disabled={!data.games.length}
+				bind:value={selectedCreateGame}
 			>
-				{#if data.games.length > 0}
-					{#each data.games as g (g)}
-						<option value={g}>{g}</option>
-					{/each}
-				{:else}
-					<option value="" disabled selected>No games available</option>
-				{/if}
+				{#each data.games as g (g)}
+					<option value={g}>{g}</option>
+				{/each}
+				<option value="__custom__">Custom game…</option>
 			</select>
+			{#if selectedCreateGame === '__custom__'}
+				<input
+					class="text-input bevel-in"
+					type="text"
+					name="custom_game"
+					bind:value={customGameName}
+					maxlength="100"
+					required
+					placeholder="Enter custom game name"
+					autocomplete="off"
+				/>
+			{/if}
+		</div>
+
+		<div class="form-row">
+			<label for="create-location" class="small-caps">Lobby Location</label>
+			<div class="select-with-action">
+				<select
+					id="create-location"
+					class="text-input bevel-in"
+					name="lobby_location"
+					required
+					bind:value={selectedCreateLocation}
+				>
+					{#each lobbyLocations as location (location.code)}
+						<option value={location.code}>{location.label}</option>
+					{/each}
+				</select>
+				<OrnateButton
+					variant="secondary"
+					size="sm"
+					disabled={detectingLocation}
+					onclick={detectLobbyLocation}
+				>
+					{detectingLocation ? 'Detecting…' : 'Auto'}
+				</OrnateButton>
+			</div>
+			{#if locationFeedback}
+				<p class="form-help">{locationFeedback}</p>
+			{/if}
 		</div>
 
 		<div class="form-row">
@@ -1332,6 +1463,21 @@
 		display: flex;
 		flex-direction: column;
 		gap: 0.4rem;
+	}
+
+	.select-with-action {
+		display: grid;
+		grid-template-columns: 1fr auto;
+		gap: 0.5rem;
+		align-items: stretch;
+	}
+
+	.form-help {
+		margin: 0;
+		font-family: var(--font-mono);
+		font-size: 0.75rem;
+		line-height: 1.35;
+		color: var(--bone-muted);
 	}
 
 	.form-row label {

--- a/frontend/src/routes/rooms/[name]/+page.server.ts
+++ b/frontend/src/routes/rooms/[name]/+page.server.ts
@@ -3,6 +3,7 @@ import { env } from '$env/dynamic/public';
 import { env as privateEnv } from '$env/dynamic/private';
 import { fail, redirect } from '@sveltejs/kit';
 import { jwtDecode } from 'jwt-decode';
+import { lobbyLocationLabel, FALLBACK_LOBBY_LOCATIONS } from '$lib/lobbyLocations';
 import type { RoomEventState } from '$lib/chatStore';
 
 function backendBase(): string {
@@ -17,6 +18,7 @@ interface SessionTokenClaims {
 interface RoomDetail {
 	name: string;
 	game: string;
+	lobby_location: string;
 	players_max: number;
 	players_active: number;
 	member_addresses: string[];
@@ -68,6 +70,8 @@ export const load: PageServerLoad = async ({ params, cookies }) => {
 	return {
 		roomName: roomDetail.name,
 		roomGame: roomDetail.game,
+		roomLocation: roomDetail.lobby_location,
+		roomLocationLabel: lobbyLocationLabel(FALLBACK_LOBBY_LOCATIONS, roomDetail.lobby_location),
 		description: roomDetail.description,
 		communicatorLink: roomDetail.communicator_link,
 		requirements: roomDetail.requirements,

--- a/frontend/src/routes/rooms/[name]/+page.svelte
+++ b/frontend/src/routes/rooms/[name]/+page.svelte
@@ -132,7 +132,9 @@
 		}));
 	});
 
-	const eventMembers = $derived(roster.map((m) => ({ address: m.address, username: m.username })));
+	const eventMembers = $derived(
+		roster.map((m) => ({ address: m.address, username: m.username }))
+	);
 
 	function isMine(addr: string): boolean {
 		return (addr ?? '').toLowerCase() === (data.address ?? '').toLowerCase();
@@ -189,6 +191,12 @@
 							<span class="game small-caps">
 								<span class="dot" aria-hidden="true">·</span>
 								Game · {data.roomGame}
+							</span>
+						{/if}
+						{#if data.roomLocationLabel}
+							<span class="game small-caps">
+								<span class="dot" aria-hidden="true">·</span>
+								Location · {data.roomLocationLabel}
 							</span>
 						{/if}
 					</div>
@@ -254,10 +262,15 @@
 										<article class="msg" class:mine class:other={!mine}>
 											<div class="msg-meta">
 												<span class="sender small-caps">
-													{mine ? 'You' : msg.sender_username || shortAddr(msg.sender_address)}
+													{mine
+														? 'You'
+														: msg.sender_username ||
+															shortAddr(msg.sender_address)}
 												</span>
 												<span class="sep" aria-hidden="true">·</span>
-												<span class="addr">{shortAddr(msg.sender_address)}</span>
+												<span class="addr"
+													>{shortAddr(msg.sender_address)}</span
+												>
 												<span class="sep" aria-hidden="true">·</span>
 												<span class="time">{fmtTime(msg.created_at)}</span>
 											</div>

--- a/frontend/src/routes/rooms/[name]/+page.svelte
+++ b/frontend/src/routes/rooms/[name]/+page.svelte
@@ -132,9 +132,7 @@
 		}));
 	});
 
-	const eventMembers = $derived(
-		roster.map((m) => ({ address: m.address, username: m.username }))
-	);
+	const eventMembers = $derived(roster.map((m) => ({ address: m.address, username: m.username })));
 
 	function isMine(addr: string): boolean {
 		return (addr ?? '').toLowerCase() === (data.address ?? '').toLowerCase();
@@ -262,15 +260,10 @@
 										<article class="msg" class:mine class:other={!mine}>
 											<div class="msg-meta">
 												<span class="sender small-caps">
-													{mine
-														? 'You'
-														: msg.sender_username ||
-															shortAddr(msg.sender_address)}
+													{mine ? 'You' : msg.sender_username || shortAddr(msg.sender_address)}
 												</span>
 												<span class="sep" aria-hidden="true">·</span>
-												<span class="addr"
-													>{shortAddr(msg.sender_address)}</span
-												>
+												<span class="addr">{shortAddr(msg.sender_address)}</span>
 												<span class="sep" aria-hidden="true">·</span>
 												<span class="time">{fmtTime(msg.created_at)}</span>
 											</div>


### PR DESCRIPTION
Introduce a lobby_location attribute for rooms throughout the stack and add region metadata. Backend: add DEFAULT_LOBBY_LOCATION and lobby_location column on Room (alembic migration), create LOBBY_LOCATIONS list and /lobby-locations endpoint, validate lobby_location on room creation, persist lobby_location, return it in room/list payloads, add _ensure_game helper to create custom games, and fix some exception handling. Tests updated to cover required/invalid locations, custom game creation, and the new endpoint. Frontend: add lobbyLocations utility (fallback list, helpers, distance calculation, nearest lookup), surface lobby locations in roomsStore and pages, include lobby_location in room creation form (with select + custom game handling and geolocation auto-detect), display room location and use location-based ping estimates, update GameManager text, and minor UI/formatting tweaks.

Closes #68 