### PR TITLE
Add background task to cleanup expired rooms

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -420,16 +420,15 @@ async def cleanup_expired_rooms_task() -> None:
                     session.commit()
                     rooms_count = len(expired_rooms)
                     logger.info(
-                        "Cleanup task deleted {} room(s) and {} message(s)".format(
-                            rooms_count, total_messages_deleted
-                        )
+                        f"""Cleanup task deleted {rooms_count} room(s)
+                        and {total_messages_deleted} message(s)"""
                     )
 
                     # Broadcast updated rooms payload to all WebSocket clients
                     rooms_payload = get_rooms_payload(session)
                     await manager.broadcast(rooms_payload)
         except Exception as exc:
-            logger.exception("Error in cleanup_expired_rooms_task: {}".format(exc))
+            logger.exception(f"Error in cleanup_expired_rooms_task: {exc}")
 
 
 @asynccontextmanager

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,5 +1,7 @@
+import asyncio
 import hashlib
 import json
+import logging
 import os
 import uuid
 from contextlib import asynccontextmanager
@@ -20,7 +22,7 @@ from pydantic import Field as PydField
 from sqlalchemy.exc import IntegrityError
 from sqlmodel import Session, select
 
-from database import get_session
+from database import engine, get_session
 from models import (
     DEFAULT_LOBBY_LOCATION,
     Game,
@@ -33,6 +35,8 @@ from models import (
     User,
 )
 from usernames import validate_username
+
+logger = logging.getLogger(__name__)
 
 # Load .env from project root if it exists
 env_path = Path(__file__).parent.parent / ".env"
@@ -51,6 +55,7 @@ if not JWT_SECRET:
 JWT_ALGORITHM = os.getenv("JWT_ALGORITHM", "HS256")
 NONCE_EXPIRATION_MINUTES = int(os.getenv("NONCE_EXPIRATION_MINUTES", "5"))
 JWT_EXPIRATION_MINUTES = int(os.getenv("JWT_EXPIRATION_MINUTES", "60"))
+ROOM_CLEANUP_INTERVAL_SECONDS = int(os.getenv("ROOM_CLEANUP_INTERVAL_SECONDS", "60"))
 
 
 def _parse_admin_addresses(raw: str | None) -> set[str]:
@@ -377,10 +382,68 @@ def seed_default_games() -> None:
             session.commit()
 
 
+async def cleanup_expired_rooms_task() -> None:
+    """Periodically clean up expired rooms from the database."""
+    while True:
+        try:
+            await asyncio.sleep(ROOM_CLEANUP_INTERVAL_SECONDS)
+
+            with Session(engine) as session:
+                now = datetime.now(UTC)
+                expired_rooms = session.exec(
+                    select(Room).where(Room.expires_at <= now)
+                ).all()
+
+                total_messages_deleted = 0
+                for er in expired_rooms:
+                    old_messages = session.exec(
+                        select(Message).where(Message.room_id == er.id)
+                    ).all()
+                    total_messages_deleted += len(old_messages)
+                    for m in old_messages:
+                        session.delete(m)
+                    old_event = session.exec(
+                        select(RoomEvent).where(RoomEvent.room_id == er.id)
+                    ).first()
+                    if old_event is not None:
+                        old_rsvps = session.exec(
+                            select(RoomEventRsvp).where(
+                                RoomEventRsvp.event_id == old_event.id
+                            )
+                        ).all()
+                        for r in old_rsvps:
+                            session.delete(r)
+                        session.delete(old_event)
+                    session.delete(er)
+
+                if expired_rooms:
+                    session.commit()
+                    rooms_count = len(expired_rooms)
+                    logger.info(
+                        "Cleanup task deleted {} room(s) and {} message(s)".format(
+                            rooms_count, total_messages_deleted
+                        )
+                    )
+
+                    # Broadcast updated rooms payload to all WebSocket clients
+                    rooms_payload = get_rooms_payload(session)
+                    await manager.broadcast(rooms_payload)
+        except Exception as exc:
+            logger.exception("Error in cleanup_expired_rooms_task: {}".format(exc))
+
+
 @asynccontextmanager
 async def lifespan(_app: FastAPI):
     seed_default_games()
-    yield
+    cleanup_task = asyncio.create_task(cleanup_expired_rooms_task())
+    try:
+        yield
+    finally:
+        cleanup_task.cancel()
+        try:
+            await cleanup_task
+        except asyncio.CancelledError:
+            logger.info("Room cleanup task cancelled during shutdown")
 
 
 app = FastAPI(lifespan=lifespan)

--- a/backend/tests/test_cleanup.py
+++ b/backend/tests/test_cleanup.py
@@ -3,7 +3,6 @@
 import json
 from datetime import UTC, datetime, timedelta
 
-from fastapi.testclient import TestClient
 from sqlmodel import Session, select
 
 from models import Message, Room, User

--- a/backend/tests/test_cleanup.py
+++ b/backend/tests/test_cleanup.py
@@ -30,9 +30,9 @@ def _auth_headers() -> tuple[dict[str, str], str]:
     return {"Authorization": f"Bearer {token}"}, address
 
 
-def test_cleanup_removes_expired_rooms(client: TestClient, session: Session):
+def test_cleanup_removes_expired_rooms(session: Session):
     """Verify that get_rooms_payload cleans up expired rooms and messages."""
-    headers, address = _auth_headers()
+    _, address = _auth_headers()
     user = User(identity_address=address)
     session.add(user)
     session.commit()
@@ -85,9 +85,9 @@ def test_cleanup_removes_expired_rooms(client: TestClient, session: Session):
     )
 
 
-def test_cleanup_does_not_remove_valid_rooms(client: TestClient, session: Session):
+def test_cleanup_does_not_remove_valid_rooms(session: Session):
     """Verify that cleanup only removes expired rooms, not valid ones."""
-    headers, address = _auth_headers()
+    _, address = _auth_headers()
     user = User(identity_address=address)
     session.add(user)
     session.commit()

--- a/backend/tests/test_cleanup.py
+++ b/backend/tests/test_cleanup.py
@@ -1,0 +1,120 @@
+"""Tests for the room cleanup functionality."""
+
+import json
+from datetime import UTC, datetime, timedelta
+
+from fastapi.testclient import TestClient
+from sqlmodel import Session, select
+
+from models import Message, Room, User
+
+
+def _auth_headers() -> tuple[dict[str, str], str]:
+    """Helper to create auth headers for tests."""
+    import os
+
+    import jwt
+    from eth_account import Account
+
+    acct = Account.create()
+    address = acct.address
+    secret = os.environ["JWT_SECRET"]
+    payload = {
+        "sub": address,
+        "username": "tester",
+        "iat": datetime.now(UTC),
+        "exp": datetime.now(UTC) + timedelta(minutes=5),
+        "iss": "playlink-auth",
+    }
+    token = jwt.encode(payload, secret, algorithm="HS256")
+    return {"Authorization": f"Bearer {token}"}, address
+
+
+def test_cleanup_removes_expired_rooms(client: TestClient, session: Session):
+    """Verify that get_rooms_payload cleans up expired rooms and messages."""
+    headers, address = _auth_headers()
+    user = User(identity_address=address)
+    session.add(user)
+    session.commit()
+    session.refresh(user)
+
+    # Create an already-expired room
+    now = datetime.now(UTC)
+    expired_room = Room(
+        name="expired-cleanup-test",
+        game="Quake III Arena",
+        lobby_location="eu-central",
+        players_max=4,
+        created_by=address,
+        created_at=now - timedelta(hours=2),
+        expires_at=now - timedelta(seconds=1),
+    )
+    expired_room.members.append(user)
+    session.add(expired_room)
+    session.commit()
+    room_id = expired_room.id
+
+    # Add a message to the expired room
+    msg = Message(
+        room_id=room_id,
+        sender_address=address,
+        content="old message",
+    )
+    session.add(msg)
+    session.commit()
+
+    # Verify they exist in DB before cleanup
+    assert session.exec(select(Room).where(Room.id == room_id)).first() is not None
+    assert (
+        len(session.exec(select(Message).where(Message.room_id == room_id)).all()) == 1
+    )
+
+    # Call get_rooms_payload which triggers cleanup
+    from main import get_rooms_payload
+
+    payload_json = get_rooms_payload(session)
+    rooms_list = json.loads(payload_json)
+
+    # Verify the expired room is not in the payload
+    assert not any(r["name"] == "expired-cleanup-test" for r in rooms_list)
+
+    # Verify the expired room and message were deleted from DB
+    assert session.exec(select(Room).where(Room.id == room_id)).first() is None
+    assert (
+        len(session.exec(select(Message).where(Message.room_id == room_id)).all()) == 0
+    )
+
+
+def test_cleanup_does_not_remove_valid_rooms(client: TestClient, session: Session):
+    """Verify that cleanup only removes expired rooms, not valid ones."""
+    headers, address = _auth_headers()
+    user = User(identity_address=address)
+    session.add(user)
+    session.commit()
+    session.refresh(user)
+
+    # Create a valid (not-expired) room
+    now = datetime.now(UTC)
+    valid_room = Room(
+        name="valid-room-test",
+        game="Diablo II",
+        lobby_location="eu-central",
+        players_max=4,
+        created_by=address,
+        created_at=now,
+        expires_at=now + timedelta(hours=1),
+    )
+    valid_room.members.append(user)
+    session.add(valid_room)
+    session.commit()
+    room_id = valid_room.id
+
+    # Call get_rooms_payload
+    from main import get_rooms_payload
+
+    payload_json = get_rooms_payload(session)
+    rooms_list = json.loads(payload_json)
+
+    # Verify the valid room still exists
+    assert any(r["name"] == "valid-room-test" for r in rooms_list)
+    assert session.exec(select(Room).where(Room.id == room_id)).first() is not None

--- a/backend/tests/test_rooms.py
+++ b/backend/tests/test_rooms.py
@@ -4,7 +4,7 @@ from datetime import UTC, datetime, timedelta
 import jwt
 from eth_account import Account
 from fastapi.testclient import TestClient
-from sqlmodel import Session, select
+from sqlmodel import Session
 
 
 def _auth_headers() -> tuple[dict[str, str], str]:

--- a/backend/tests/test_rooms.py
+++ b/backend/tests/test_rooms.py
@@ -4,7 +4,7 @@ from datetime import UTC, datetime, timedelta
 import jwt
 from eth_account import Account
 from fastapi.testclient import TestClient
-from sqlmodel import Session
+from sqlmodel import Session, select
 
 
 def _auth_headers() -> tuple[dict[str, str], str]:


### PR DESCRIPTION
Introduce an async cleanup task that periodically removes expired Room rows and their related Message and RoomEvent/RoomEventRsvp records, then broadcasts updated rooms to connected WebSocket clients. Main changes: import asyncio, logging and engine; add ROOM_CLEANUP_INTERVAL_SECONDS env var; implement cleanup_expired_rooms_task with error handling and logging; start the task in the app lifespan and ensure it is cancelled on shutdown. Also add tests (tests/test_cleanup.py) verifying expired rooms/messages are removed and valid rooms remain, and adjust an import in tests/test_rooms.py to include select.

Closes #57 