### PR TITLE
feat: rate limiting on auth, room creation, and chat (#58)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,3 +19,8 @@ JWT_EXPIRATION_MINUTES=60
 # Comma-separated identity addresses granted admin privileges (case-insensitive).
 # Leave empty for no admins. Example: 0xAddress1,0xAddress2
 ADMIN_ADDRESSES=
+
+# Rate Limit Configuration
+DEFAULT_RATE_LIMIT=10/minute
+WS_RATE_LIMIT_MAX_MESSAGES=10
+WS_RATE_LIMIT_TIME_WINDW_SECONDS=10

--- a/backend/main.py
+++ b/backend/main.py
@@ -3,8 +3,8 @@ import hashlib
 import json
 import logging
 import os
-import uuid
 import time
+import uuid
 from collections import defaultdict
 from contextlib import asynccontextmanager
 from datetime import UTC, datetime, timedelta
@@ -16,18 +16,24 @@ from dotenv import load_dotenv
 from eth_account import Account
 from eth_account.messages import encode_defunct
 from eth_utils.address import to_checksum_address
-from fastapi import Depends, FastAPI, HTTPException, WebSocket, WebSocketDisconnect, Request
+from fastapi import (
+    Depends,
+    FastAPI,
+    HTTPException,
+    Request,
+    WebSocket,
+    WebSocketDisconnect,
+)
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.security import OAuth2PasswordBearer
 from pydantic import BaseModel, HttpUrl
 from pydantic import Field as PydField
+from slowapi import Limiter
+from slowapi.errors import RateLimitExceeded
+from slowapi.extension import _rate_limit_exceeded_handler
+from slowapi.util import get_remote_address
 from sqlalchemy.exc import IntegrityError
 from sqlmodel import Session, select
-from slowapi import Limiter
-from slowapi.util import get_remote_address
-from slowapi.errors import RateLimitExceeded
-from slowapi.middleware import SlowAPIMiddleware
-from slowapi.extension import _rate_limit_exceeded_handler
 
 from database import engine, get_session
 from models import (
@@ -489,13 +495,13 @@ app.add_middleware(
 
 @app.get("/")
 @limiter.limit(DEFAULT_RATE_LIMIT)
-def read_root(request: Request):
+def read_root(request: Request): # noqa: ARG001
     return {"status": "ok", "service": "playlink-auth"}
 
 
 @app.post("/auth/request-nonce")
 @limiter.limit(DEFAULT_RATE_LIMIT)
-def request_nonce(request: Request, address: str, session: SessionDep):
+def request_nonce(request: Request, address: str, session: SessionDep): # noqa: ARG001
     """
     Request a one-time nonce for an identity address.
     """
@@ -547,7 +553,7 @@ def request_nonce(request: Request, address: str, session: SessionDep):
 
 @app.post("/auth/verify")
 @limiter.limit(DEFAULT_RATE_LIMIT)
-def verify_signature(request: Request, body: VerifyRequest, session: SessionDep):
+def verify_signature(request: Request, body: VerifyRequest, session: SessionDep): # noqa: ARG001
     """
     Verify signature against a nonce and issue a JWT.
     """
@@ -640,7 +646,7 @@ class UpdateUserRequest(BaseModel):
 @app.get("/users/me")
 @limiter.limit(DEFAULT_RATE_LIMIT)
 def get_me(
-    request: Request,
+    request: Request, # noqa: ARG001
     session: SessionDep,
     address: Annotated[str, Depends(get_current_user_address)],
 ):
@@ -653,7 +659,7 @@ def get_me(
 @app.patch("/users/me")
 @limiter.limit(DEFAULT_RATE_LIMIT)
 def update_me(
-    request: Request,
+    request: Request, # noqa: ARG001
     payload: UpdateUserRequest,
     session: SessionDep,
     address: Annotated[str, Depends(get_current_user_address)],
@@ -695,19 +701,19 @@ def update_me(
 
 @app.get("/rooms")
 @limiter.limit(DEFAULT_RATE_LIMIT)
-def list_rooms(request: Request, session: SessionDep):
+def list_rooms(request: Request, session: SessionDep): # noqa: ARG001
     return session.exec(select(Room)).all()
 
 
 @app.get("/lobby-locations")
 @limiter.limit(DEFAULT_RATE_LIMIT)
-def list_lobby_locations(request: Request):
+def list_lobby_locations(request: Request): # noqa: ARG001
     return {"default": DEFAULT_LOBBY_LOCATION, "locations": LOBBY_LOCATIONS}
 
 
 @app.get("/rooms/{room_name}")
 @limiter.limit(DEFAULT_RATE_LIMIT)
-def get_room(request: Request, room_name: str, session: SessionDep):
+def get_room(request: Request, room_name: str, session: SessionDep): # noqa: ARG001
     room = session.exec(select(Room).where(Room.name == room_name)).first()
     if not room:
         raise HTTPException(status_code=404, detail="Room not found")
@@ -733,7 +739,7 @@ def get_room(request: Request, room_name: str, session: SessionDep):
 
 @app.get("/games")
 @limiter.limit(DEFAULT_RATE_LIMIT)
-def list_games(request: Request, session: SessionDep):
+def list_games(request: Request, session: SessionDep): # noqa: ARG001
     games = session.exec(select(Game).order_by(Game.sort_order)).all()
     return [game.name for game in games]
 
@@ -745,7 +751,7 @@ def list_games(request: Request, session: SessionDep):
 )
 @limiter.limit(DEFAULT_RATE_LIMIT)
 async def delete_room(
-    request: Request,
+    request: Request, # noqa: ARG001
     room_name: str,
     session: SessionDep,
 ):
@@ -773,7 +779,7 @@ async def delete_room(
 @app.post("/games", status_code=201, dependencies=[Depends(get_admin_address)])
 @limiter.limit(DEFAULT_RATE_LIMIT)
 async def create_game(
-    request: Request,
+    request: Request, # noqa: ARG001
     body: CreateGameRequest,
     session: SessionDep,
 ):
@@ -799,7 +805,7 @@ async def create_game(
 @app.delete("/games/{name}", status_code=200, dependencies=[Depends(get_admin_address)])
 @limiter.limit(DEFAULT_RATE_LIMIT)
 async def delete_game(
-    request: Request,
+    request: Request, # noqa: ARG001
     name: str,
     session: SessionDep,
     force: bool = False,
@@ -839,7 +845,7 @@ async def delete_game(
 @app.post("/rooms", status_code=201)
 @limiter.limit(DEFAULT_RATE_LIMIT)
 async def create_room(
-    request: Request,
+    request: Request, # noqa: ARG001
     body: CreateRoomRequest,
     session: SessionDep,
     address: Annotated[str, Depends(get_current_user_address)],
@@ -908,7 +914,7 @@ async def create_room(
 @app.post("/rooms/{room_name}/join", status_code=200)
 @limiter.limit(DEFAULT_RATE_LIMIT)
 async def join_room(
-    request: Request,
+    request: Request, # noqa: ARG001
     room_name: str,
     session: SessionDep,
     address: Annotated[str, Depends(get_current_user_address)],
@@ -942,7 +948,7 @@ async def join_room(
 @app.post("/rooms/{room_name}/leave", status_code=200)
 @limiter.limit(DEFAULT_RATE_LIMIT)
 async def leave_room(
-    request: Request,
+    request: Request, # noqa: ARG001
     room_name: str,
     session: SessionDep,
     address: Annotated[str, Depends(get_current_user_address)],
@@ -993,7 +999,7 @@ async def leave_room(
 
 @app.get("/rooms/{room_name}/event")
 @limiter.limit(DEFAULT_RATE_LIMIT)
-def get_room_event(request: Request, room_name: str, session: SessionDep):
+def get_room_event(request: Request, room_name: str, session: SessionDep): # noqa: ARG001
     """Return the room's scheduled event (if any), including the RSVP roster.
 
     Mirrors `GET /rooms/{name}` in being public — anyone can browse the
@@ -1011,12 +1017,12 @@ def get_room_event(request: Request, room_name: str, session: SessionDep):
 @app.put("/rooms/{room_name}/event", status_code=200)
 @limiter.limit(DEFAULT_RATE_LIMIT)
 async def schedule_room_event(
-    request: Request,
+    request: Request, # noqa: ARG001
     room_name: str,
     body: ScheduleEventRequest,
     session: SessionDep,
     address: Annotated[str, Depends(get_current_user_address)],
-):
+): 
     """Create or replace the scheduled event for a room.
 
     Only the room creator may schedule. `starts_at` must lie in the future
@@ -1105,7 +1111,7 @@ async def schedule_room_event(
 @app.delete("/rooms/{room_name}/event", status_code=200)
 @limiter.limit(DEFAULT_RATE_LIMIT)
 async def cancel_room_event(
-    request: Request,
+    request: Request, # noqa: ARG001
     room_name: str,
     session: SessionDep,
     address: Annotated[str, Depends(get_current_user_address)],
@@ -1140,7 +1146,7 @@ async def cancel_room_event(
 
 @app.put("/rooms/{room_name}/event/rsvp", status_code=200)
 async def set_room_event_rsvp(
-    request: Request,
+    request: Request, # noqa: ARG001
     room_name: str,
     body: SetRsvpRequest,
     session: SessionDep,

--- a/backend/main.py
+++ b/backend/main.py
@@ -77,6 +77,7 @@ WS_LIMITS = defaultdict(list)
 MAX_MSGS = int(os.getenv("WS_RATE_LIMIT_MAX_MESSAGES", "10"))
 WINDOW = int(os.getenv("WS_RATE_LIMIT_TIME_WINDOW_SECONDS", "10"))
 
+
 def _parse_admin_addresses(raw: str | None) -> set[str]:
     """Parse the comma-separated `ADMIN_ADDRESSES` env value into a set.
 
@@ -469,10 +470,7 @@ app = FastAPI(lifespan=lifespan)
 limiter = Limiter(key_func=get_remote_address)
 
 app.state.limiter = limiter
-app.add_exception_handler(
-    RateLimitExceeded,
-    _rate_limit_exceeded_handler
-)
+app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
 
 origins = [
     "https://playlink.bartek.monster",
@@ -495,13 +493,13 @@ app.add_middleware(
 
 @app.get("/")
 @limiter.limit(DEFAULT_RATE_LIMIT)
-def read_root(request: Request): # noqa: ARG001
+def read_root(request: Request):  # noqa: ARG001
     return {"status": "ok", "service": "playlink-auth"}
 
 
 @app.post("/auth/request-nonce")
 @limiter.limit(DEFAULT_RATE_LIMIT)
-def request_nonce(request: Request, address: str, session: SessionDep): # noqa: ARG001
+def request_nonce(request: Request, address: str, session: SessionDep):  # noqa: ARG001
     """
     Request a one-time nonce for an identity address.
     """
@@ -553,7 +551,7 @@ def request_nonce(request: Request, address: str, session: SessionDep): # noqa: 
 
 @app.post("/auth/verify")
 @limiter.limit(DEFAULT_RATE_LIMIT)
-def verify_signature(request: Request, body: VerifyRequest, session: SessionDep): # noqa: ARG001
+def verify_signature(request: Request, body: VerifyRequest, session: SessionDep):  # noqa: ARG001
     """
     Verify signature against a nonce and issue a JWT.
     """
@@ -646,7 +644,7 @@ class UpdateUserRequest(BaseModel):
 @app.get("/users/me")
 @limiter.limit(DEFAULT_RATE_LIMIT)
 def get_me(
-    request: Request, # noqa: ARG001
+    request: Request,  # noqa: ARG001
     session: SessionDep,
     address: Annotated[str, Depends(get_current_user_address)],
 ):
@@ -659,7 +657,7 @@ def get_me(
 @app.patch("/users/me")
 @limiter.limit(DEFAULT_RATE_LIMIT)
 def update_me(
-    request: Request, # noqa: ARG001
+    request: Request,  # noqa: ARG001
     payload: UpdateUserRequest,
     session: SessionDep,
     address: Annotated[str, Depends(get_current_user_address)],
@@ -701,19 +699,19 @@ def update_me(
 
 @app.get("/rooms")
 @limiter.limit(DEFAULT_RATE_LIMIT)
-def list_rooms(request: Request, session: SessionDep): # noqa: ARG001
+def list_rooms(request: Request, session: SessionDep):  # noqa: ARG001
     return session.exec(select(Room)).all()
 
 
 @app.get("/lobby-locations")
 @limiter.limit(DEFAULT_RATE_LIMIT)
-def list_lobby_locations(request: Request): # noqa: ARG001
+def list_lobby_locations(request: Request):  # noqa: ARG001
     return {"default": DEFAULT_LOBBY_LOCATION, "locations": LOBBY_LOCATIONS}
 
 
 @app.get("/rooms/{room_name}")
 @limiter.limit(DEFAULT_RATE_LIMIT)
-def get_room(request: Request, room_name: str, session: SessionDep): # noqa: ARG001
+def get_room(request: Request, room_name: str, session: SessionDep):  # noqa: ARG001
     room = session.exec(select(Room).where(Room.name == room_name)).first()
     if not room:
         raise HTTPException(status_code=404, detail="Room not found")
@@ -739,7 +737,7 @@ def get_room(request: Request, room_name: str, session: SessionDep): # noqa: ARG
 
 @app.get("/games")
 @limiter.limit(DEFAULT_RATE_LIMIT)
-def list_games(request: Request, session: SessionDep): # noqa: ARG001
+def list_games(request: Request, session: SessionDep):  # noqa: ARG001
     games = session.exec(select(Game).order_by(Game.sort_order)).all()
     return [game.name for game in games]
 
@@ -751,7 +749,7 @@ def list_games(request: Request, session: SessionDep): # noqa: ARG001
 )
 @limiter.limit(DEFAULT_RATE_LIMIT)
 async def delete_room(
-    request: Request, # noqa: ARG001
+    request: Request,  # noqa: ARG001
     room_name: str,
     session: SessionDep,
 ):
@@ -779,7 +777,7 @@ async def delete_room(
 @app.post("/games", status_code=201, dependencies=[Depends(get_admin_address)])
 @limiter.limit(DEFAULT_RATE_LIMIT)
 async def create_game(
-    request: Request, # noqa: ARG001
+    request: Request,  # noqa: ARG001
     body: CreateGameRequest,
     session: SessionDep,
 ):
@@ -805,7 +803,7 @@ async def create_game(
 @app.delete("/games/{name}", status_code=200, dependencies=[Depends(get_admin_address)])
 @limiter.limit(DEFAULT_RATE_LIMIT)
 async def delete_game(
-    request: Request, # noqa: ARG001
+    request: Request,  # noqa: ARG001
     name: str,
     session: SessionDep,
     force: bool = False,
@@ -845,7 +843,7 @@ async def delete_game(
 @app.post("/rooms", status_code=201)
 @limiter.limit(DEFAULT_RATE_LIMIT)
 async def create_room(
-    request: Request, # noqa: ARG001
+    request: Request,  # noqa: ARG001
     body: CreateRoomRequest,
     session: SessionDep,
     address: Annotated[str, Depends(get_current_user_address)],
@@ -914,7 +912,7 @@ async def create_room(
 @app.post("/rooms/{room_name}/join", status_code=200)
 @limiter.limit(DEFAULT_RATE_LIMIT)
 async def join_room(
-    request: Request, # noqa: ARG001
+    request: Request,  # noqa: ARG001
     room_name: str,
     session: SessionDep,
     address: Annotated[str, Depends(get_current_user_address)],
@@ -948,7 +946,7 @@ async def join_room(
 @app.post("/rooms/{room_name}/leave", status_code=200)
 @limiter.limit(DEFAULT_RATE_LIMIT)
 async def leave_room(
-    request: Request, # noqa: ARG001
+    request: Request,  # noqa: ARG001
     room_name: str,
     session: SessionDep,
     address: Annotated[str, Depends(get_current_user_address)],
@@ -999,7 +997,7 @@ async def leave_room(
 
 @app.get("/rooms/{room_name}/event")
 @limiter.limit(DEFAULT_RATE_LIMIT)
-def get_room_event(request: Request, room_name: str, session: SessionDep): # noqa: ARG001
+def get_room_event(request: Request, room_name: str, session: SessionDep):  # noqa: ARG001
     """Return the room's scheduled event (if any), including the RSVP roster.
 
     Mirrors `GET /rooms/{name}` in being public — anyone can browse the
@@ -1017,12 +1015,12 @@ def get_room_event(request: Request, room_name: str, session: SessionDep): # noq
 @app.put("/rooms/{room_name}/event", status_code=200)
 @limiter.limit(DEFAULT_RATE_LIMIT)
 async def schedule_room_event(
-    request: Request, # noqa: ARG001
+    request: Request,  # noqa: ARG001
     room_name: str,
     body: ScheduleEventRequest,
     session: SessionDep,
     address: Annotated[str, Depends(get_current_user_address)],
-): 
+):
     """Create or replace the scheduled event for a room.
 
     Only the room creator may schedule. `starts_at` must lie in the future
@@ -1111,7 +1109,7 @@ async def schedule_room_event(
 @app.delete("/rooms/{room_name}/event", status_code=200)
 @limiter.limit(DEFAULT_RATE_LIMIT)
 async def cancel_room_event(
-    request: Request, # noqa: ARG001
+    request: Request,  # noqa: ARG001
     room_name: str,
     session: SessionDep,
     address: Annotated[str, Depends(get_current_user_address)],
@@ -1146,7 +1144,7 @@ async def cancel_room_event(
 
 @app.put("/rooms/{room_name}/event/rsvp", status_code=200)
 async def set_room_event_rsvp(
-    request: Request, # noqa: ARG001
+    request: Request,  # noqa: ARG001
     room_name: str,
     body: SetRsvpRequest,
     session: SessionDep,
@@ -1292,10 +1290,7 @@ async def websocket_chat(
 
             key = address
 
-            WS_LIMITS[key] = [
-                t for t in WS_LIMITS[key]
-                if now - t < WINDOW
-            ]
+            WS_LIMITS[key] = [t for t in WS_LIMITS[key] if now - t < WINDOW]
 
             if len(WS_LIMITS[key]) >= MAX_MSGS:
                 await websocket.close(code=4429)

--- a/backend/main.py
+++ b/backend/main.py
@@ -1143,6 +1143,7 @@ async def cancel_room_event(
 
 
 @app.put("/rooms/{room_name}/event/rsvp", status_code=200)
+@limiter.limit(DEFAULT_RATE_LIMIT)
 async def set_room_event_rsvp(
     request: Request,  # noqa: ARG001
     room_name: str,

--- a/backend/main.py
+++ b/backend/main.py
@@ -4,6 +4,7 @@ import json
 import logging
 import os
 import uuid
+import time
 from collections import defaultdict
 from contextlib import asynccontextmanager
 from datetime import UTC, datetime, timedelta

--- a/backend/main.py
+++ b/backend/main.py
@@ -4,6 +4,7 @@ import json
 import logging
 import os
 import uuid
+from collections import defaultdict
 from contextlib import asynccontextmanager
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
@@ -14,13 +15,18 @@ from dotenv import load_dotenv
 from eth_account import Account
 from eth_account.messages import encode_defunct
 from eth_utils.address import to_checksum_address
-from fastapi import Depends, FastAPI, HTTPException, WebSocket, WebSocketDisconnect
+from fastapi import Depends, FastAPI, HTTPException, WebSocket, WebSocketDisconnect, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.security import OAuth2PasswordBearer
 from pydantic import BaseModel, HttpUrl
 from pydantic import Field as PydField
 from sqlalchemy.exc import IntegrityError
 from sqlmodel import Session, select
+from slowapi import Limiter
+from slowapi.util import get_remote_address
+from slowapi.errors import RateLimitExceeded
+from slowapi.middleware import SlowAPIMiddleware
+from slowapi.extension import _rate_limit_exceeded_handler
 
 from database import engine, get_session
 from models import (
@@ -57,6 +63,10 @@ NONCE_EXPIRATION_MINUTES = int(os.getenv("NONCE_EXPIRATION_MINUTES", "5"))
 JWT_EXPIRATION_MINUTES = int(os.getenv("JWT_EXPIRATION_MINUTES", "60"))
 ROOM_CLEANUP_INTERVAL_SECONDS = int(os.getenv("ROOM_CLEANUP_INTERVAL_SECONDS", "60"))
 
+WS_LIMITS = defaultdict(list)
+
+MAX_MSGS = 10
+WINDOW = 60
 
 def _parse_admin_addresses(raw: str | None) -> set[str]:
     """Parse the comma-separated `ADMIN_ADDRESSES` env value into a set.
@@ -447,6 +457,14 @@ async def lifespan(_app: FastAPI):
 
 app = FastAPI(lifespan=lifespan)
 
+limiter = Limiter(key_func=get_remote_address)
+
+app.state.limiter = limiter
+app.add_exception_handler(
+    RateLimitExceeded,
+    _rate_limit_exceeded_handler
+)
+
 origins = [
     "https://playlink.bartek.monster",
     "http://localhost:3000",
@@ -467,12 +485,14 @@ app.add_middleware(
 
 
 @app.get("/")
-def read_root():
+@limiter.limit("10/minute")
+def read_root(request: Request):
     return {"status": "ok", "service": "playlink-auth"}
 
 
 @app.post("/auth/request-nonce")
-def request_nonce(address: str, session: SessionDep):
+@limiter.limit("10/minute")
+def request_nonce(request: Request, address: str, session: SessionDep):
     """
     Request a one-time nonce for an identity address.
     """
@@ -523,7 +543,8 @@ def request_nonce(address: str, session: SessionDep):
 
 
 @app.post("/auth/verify")
-def verify_signature(body: VerifyRequest, session: SessionDep):
+@limiter.limit("10/minute")
+def verify_signature(request: Request, body: VerifyRequest, session: SessionDep):
     """
     Verify signature against a nonce and issue a JWT.
     """
@@ -614,7 +635,9 @@ class UpdateUserRequest(BaseModel):
 
 
 @app.get("/users/me")
+@limiter.limit("10/minute")
 def get_me(
+    request: Request,
     session: SessionDep,
     address: Annotated[str, Depends(get_current_user_address)],
 ):
@@ -625,7 +648,9 @@ def get_me(
 
 
 @app.patch("/users/me")
+@limiter.limit("10/minute")
 def update_me(
+    request: Request,
     payload: UpdateUserRequest,
     session: SessionDep,
     address: Annotated[str, Depends(get_current_user_address)],
@@ -666,17 +691,20 @@ def update_me(
 
 
 @app.get("/rooms")
-def list_rooms(session: SessionDep):
+@limiter.limit("10/minute")
+def list_rooms(request: Request, session: SessionDep):
     return session.exec(select(Room)).all()
 
 
 @app.get("/lobby-locations")
-def list_lobby_locations():
+@limiter.limit("10/minute")
+def list_lobby_locations(request: Request):
     return {"default": DEFAULT_LOBBY_LOCATION, "locations": LOBBY_LOCATIONS}
 
 
 @app.get("/rooms/{room_name}")
-def get_room(room_name: str, session: SessionDep):
+@limiter.limit("10/minute")
+def get_room(request: Request, room_name: str, session: SessionDep):
     room = session.exec(select(Room).where(Room.name == room_name)).first()
     if not room:
         raise HTTPException(status_code=404, detail="Room not found")
@@ -701,7 +729,8 @@ def get_room(room_name: str, session: SessionDep):
 
 
 @app.get("/games")
-def list_games(session: SessionDep):
+@limiter.limit("10/minute")
+def list_games(request: Request, session: SessionDep):
     games = session.exec(select(Game).order_by(Game.sort_order)).all()
     return [game.name for game in games]
 
@@ -711,7 +740,9 @@ def list_games(session: SessionDep):
     status_code=200,
     dependencies=[Depends(get_admin_address)],
 )
+@limiter.limit("10/minute")
 async def delete_room(
+    request: Request,
     room_name: str,
     session: SessionDep,
 ):
@@ -737,7 +768,9 @@ async def delete_room(
 
 
 @app.post("/games", status_code=201, dependencies=[Depends(get_admin_address)])
+@limiter.limit("10/minute")
 async def create_game(
+    request: Request,
     body: CreateGameRequest,
     session: SessionDep,
 ):
@@ -761,7 +794,9 @@ async def create_game(
 
 
 @app.delete("/games/{name}", status_code=200, dependencies=[Depends(get_admin_address)])
+@limiter.limit("10/minute")
 async def delete_game(
+    request: Request,
     name: str,
     session: SessionDep,
     force: bool = False,
@@ -799,7 +834,9 @@ async def delete_game(
 
 
 @app.post("/rooms", status_code=201)
+@limiter.limit("10/minute")
 async def create_room(
+    request: Request,
     body: CreateRoomRequest,
     session: SessionDep,
     address: Annotated[str, Depends(get_current_user_address)],
@@ -866,7 +903,9 @@ async def create_room(
 
 
 @app.post("/rooms/{room_name}/join", status_code=200)
+@limiter.limit("10/minute")
 async def join_room(
+    request: Request,
     room_name: str,
     session: SessionDep,
     address: Annotated[str, Depends(get_current_user_address)],
@@ -898,7 +937,9 @@ async def join_room(
 
 
 @app.post("/rooms/{room_name}/leave", status_code=200)
+@limiter.limit("10/minute")
 async def leave_room(
+    request: Request,
     room_name: str,
     session: SessionDep,
     address: Annotated[str, Depends(get_current_user_address)],
@@ -948,7 +989,8 @@ async def leave_room(
 
 
 @app.get("/rooms/{room_name}/event")
-def get_room_event(room_name: str, session: SessionDep):
+@limiter.limit("10/minute")
+def get_room_event(request: Request, room_name: str, session: SessionDep):
     """Return the room's scheduled event (if any), including the RSVP roster.
 
     Mirrors `GET /rooms/{name}` in being public — anyone can browse the
@@ -964,7 +1006,9 @@ def get_room_event(room_name: str, session: SessionDep):
 
 
 @app.put("/rooms/{room_name}/event", status_code=200)
+@limiter.limit("10/minute")
 async def schedule_room_event(
+    request: Request,
     room_name: str,
     body: ScheduleEventRequest,
     session: SessionDep,
@@ -1056,7 +1100,9 @@ async def schedule_room_event(
 
 
 @app.delete("/rooms/{room_name}/event", status_code=200)
+@limiter.limit("10/minute")
 async def cancel_room_event(
+    request: Request,
     room_name: str,
     session: SessionDep,
     address: Annotated[str, Depends(get_current_user_address)],
@@ -1091,6 +1137,7 @@ async def cancel_room_event(
 
 @app.put("/rooms/{room_name}/event/rsvp", status_code=200)
 async def set_room_event_rsvp(
+    request: Request,
     room_name: str,
     body: SetRsvpRequest,
     session: SessionDep,
@@ -1232,6 +1279,21 @@ async def websocket_chat(
 
         while True:
             raw = await websocket.receive_text()
+            now = time.time()
+
+            key = address
+
+            WS_LIMITS[key] = [
+                t for t in WS_LIMITS[key]
+                if now - t < WINDOW
+            ]
+
+            if len(WS_LIMITS[key]) >= MAX_MSGS:
+                await websocket.close(code=4429)
+                return
+
+            WS_LIMITS[key].append(now)
+
             try:
                 data = json.loads(raw)
                 content = str(data.get("content", "")).strip()

--- a/backend/main.py
+++ b/backend/main.py
@@ -64,10 +64,12 @@ NONCE_EXPIRATION_MINUTES = int(os.getenv("NONCE_EXPIRATION_MINUTES", "5"))
 JWT_EXPIRATION_MINUTES = int(os.getenv("JWT_EXPIRATION_MINUTES", "60"))
 ROOM_CLEANUP_INTERVAL_SECONDS = int(os.getenv("ROOM_CLEANUP_INTERVAL_SECONDS", "60"))
 
+DEFAULT_RATE_LIMIT = os.getenv("DEFAULT_RATE_LIMIT", "10/minute")
+
 WS_LIMITS = defaultdict(list)
 
-MAX_MSGS = 10
-WINDOW = 60
+MAX_MSGS = int(os.getenv("WS_RATE_LIMIT_MAX_MESSAGES", "10"))
+WINDOW = int(os.getenv("WS_RATE_LIMIT_TIME_WINDOW_SECONDS", "10"))
 
 def _parse_admin_addresses(raw: str | None) -> set[str]:
     """Parse the comma-separated `ADMIN_ADDRESSES` env value into a set.
@@ -486,13 +488,13 @@ app.add_middleware(
 
 
 @app.get("/")
-@limiter.limit("10/minute")
+@limiter.limit(DEFAULT_RATE_LIMIT)
 def read_root(request: Request):
     return {"status": "ok", "service": "playlink-auth"}
 
 
 @app.post("/auth/request-nonce")
-@limiter.limit("10/minute")
+@limiter.limit(DEFAULT_RATE_LIMIT)
 def request_nonce(request: Request, address: str, session: SessionDep):
     """
     Request a one-time nonce for an identity address.
@@ -544,7 +546,7 @@ def request_nonce(request: Request, address: str, session: SessionDep):
 
 
 @app.post("/auth/verify")
-@limiter.limit("10/minute")
+@limiter.limit(DEFAULT_RATE_LIMIT)
 def verify_signature(request: Request, body: VerifyRequest, session: SessionDep):
     """
     Verify signature against a nonce and issue a JWT.
@@ -636,7 +638,7 @@ class UpdateUserRequest(BaseModel):
 
 
 @app.get("/users/me")
-@limiter.limit("10/minute")
+@limiter.limit(DEFAULT_RATE_LIMIT)
 def get_me(
     request: Request,
     session: SessionDep,
@@ -649,7 +651,7 @@ def get_me(
 
 
 @app.patch("/users/me")
-@limiter.limit("10/minute")
+@limiter.limit(DEFAULT_RATE_LIMIT)
 def update_me(
     request: Request,
     payload: UpdateUserRequest,
@@ -692,19 +694,19 @@ def update_me(
 
 
 @app.get("/rooms")
-@limiter.limit("10/minute")
+@limiter.limit(DEFAULT_RATE_LIMIT)
 def list_rooms(request: Request, session: SessionDep):
     return session.exec(select(Room)).all()
 
 
 @app.get("/lobby-locations")
-@limiter.limit("10/minute")
+@limiter.limit(DEFAULT_RATE_LIMIT)
 def list_lobby_locations(request: Request):
     return {"default": DEFAULT_LOBBY_LOCATION, "locations": LOBBY_LOCATIONS}
 
 
 @app.get("/rooms/{room_name}")
-@limiter.limit("10/minute")
+@limiter.limit(DEFAULT_RATE_LIMIT)
 def get_room(request: Request, room_name: str, session: SessionDep):
     room = session.exec(select(Room).where(Room.name == room_name)).first()
     if not room:
@@ -730,7 +732,7 @@ def get_room(request: Request, room_name: str, session: SessionDep):
 
 
 @app.get("/games")
-@limiter.limit("10/minute")
+@limiter.limit(DEFAULT_RATE_LIMIT)
 def list_games(request: Request, session: SessionDep):
     games = session.exec(select(Game).order_by(Game.sort_order)).all()
     return [game.name for game in games]
@@ -741,7 +743,7 @@ def list_games(request: Request, session: SessionDep):
     status_code=200,
     dependencies=[Depends(get_admin_address)],
 )
-@limiter.limit("10/minute")
+@limiter.limit(DEFAULT_RATE_LIMIT)
 async def delete_room(
     request: Request,
     room_name: str,
@@ -769,7 +771,7 @@ async def delete_room(
 
 
 @app.post("/games", status_code=201, dependencies=[Depends(get_admin_address)])
-@limiter.limit("10/minute")
+@limiter.limit(DEFAULT_RATE_LIMIT)
 async def create_game(
     request: Request,
     body: CreateGameRequest,
@@ -795,7 +797,7 @@ async def create_game(
 
 
 @app.delete("/games/{name}", status_code=200, dependencies=[Depends(get_admin_address)])
-@limiter.limit("10/minute")
+@limiter.limit(DEFAULT_RATE_LIMIT)
 async def delete_game(
     request: Request,
     name: str,
@@ -835,7 +837,7 @@ async def delete_game(
 
 
 @app.post("/rooms", status_code=201)
-@limiter.limit("10/minute")
+@limiter.limit(DEFAULT_RATE_LIMIT)
 async def create_room(
     request: Request,
     body: CreateRoomRequest,
@@ -904,7 +906,7 @@ async def create_room(
 
 
 @app.post("/rooms/{room_name}/join", status_code=200)
-@limiter.limit("10/minute")
+@limiter.limit(DEFAULT_RATE_LIMIT)
 async def join_room(
     request: Request,
     room_name: str,
@@ -938,7 +940,7 @@ async def join_room(
 
 
 @app.post("/rooms/{room_name}/leave", status_code=200)
-@limiter.limit("10/minute")
+@limiter.limit(DEFAULT_RATE_LIMIT)
 async def leave_room(
     request: Request,
     room_name: str,
@@ -990,7 +992,7 @@ async def leave_room(
 
 
 @app.get("/rooms/{room_name}/event")
-@limiter.limit("10/minute")
+@limiter.limit(DEFAULT_RATE_LIMIT)
 def get_room_event(request: Request, room_name: str, session: SessionDep):
     """Return the room's scheduled event (if any), including the RSVP roster.
 
@@ -1007,7 +1009,7 @@ def get_room_event(request: Request, room_name: str, session: SessionDep):
 
 
 @app.put("/rooms/{room_name}/event", status_code=200)
-@limiter.limit("10/minute")
+@limiter.limit(DEFAULT_RATE_LIMIT)
 async def schedule_room_event(
     request: Request,
     room_name: str,
@@ -1101,7 +1103,7 @@ async def schedule_room_event(
 
 
 @app.delete("/rooms/{room_name}/event", status_code=200)
-@limiter.limit("10/minute")
+@limiter.limit(DEFAULT_RATE_LIMIT)
 async def cancel_room_event(
     request: Request,
     room_name: str,

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
     "psycopg[binary]>=3.3.3",
     "pyjwt>=2.12.1",
     "python-dotenv>=1.2.2",
+    "slowapi>=0.1.9",
     "sqlmodel>=0.0.37",
     "uvicorn[standard]==0.41.0",
 ]

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -40,6 +40,7 @@ def client_fixture(session: Session):
     yield client
     app.dependency_overrides.clear()
 
+
 @pytest.fixture(autouse=True)
 def disable_rate_limit():
     app.state.limiter.enabled = False

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -39,3 +39,7 @@ def client_fixture(session: Session):
     client = TestClient(app)
     yield client
     app.dependency_overrides.clear()
+
+@pytest.fixture(autouse=True)
+def disable_rate_limit():
+    app.state.limiter.enabled = False

--- a/backend/tests/test_room_events.py
+++ b/backend/tests/test_room_events.py
@@ -528,59 +528,59 @@ def test_expired_room_is_pruned_with_event_and_rsvps(
 # ---------- realtime broadcast over the chat WebSocket ----------
 
 
-# def test_schedule_event_broadcasts_event_update(client: TestClient, session: Session):
-#     _seed_room(session, "lobby-1", ["0xCreator", "0xMember"])
-#     creator_t = _mint_token("0xCreator")
-#     member_t = _mint_token("0xMember")
+def test_schedule_event_broadcasts_event_update(client: TestClient, session: Session):
+    _seed_room(session, "lobby-1", ["0xCreator", "0xMember"])
+    creator_t = _mint_token("0xCreator")
+    member_t = _mint_token("0xMember")
 
-#     with (
-#         client.websocket_connect(f"/ws/rooms/lobby-1/chat?token={creator_t}") as ws_a,
-#         client.websocket_connect(f"/ws/rooms/lobby-1/chat?token={member_t}") as ws_b,
-#     ):
-#         ws_a.receive_json()  # history
-#         ws_b.receive_json()
+    with (
+        client.websocket_connect(f"/ws/rooms/lobby-1/chat?token={creator_t}") as ws_a,
+        client.websocket_connect(f"/ws/rooms/lobby-1/chat?token={member_t}") as ws_b,
+    ):
+        ws_a.receive_json()  # history
+        ws_b.receive_json()
 
-#         client.put(
-#             "/rooms/lobby-1/event",
-#             json=_event_body(30),
-#             headers=_auth_headers("0xCreator"),
-#         )
+        client.put(
+            "/rooms/lobby-1/event",
+            json=_event_body(30),
+            headers=_auth_headers("0xCreator"),
+        )
 
-#         for ws in (ws_a, ws_b):
-#             frame = ws.receive_json()
-#             assert frame["type"] == "event_update"
-#             assert frame["event"]["created_by"] == "0xCreator"
-#             assert frame["event"]["rsvps"] == []
+        for ws in (ws_a, ws_b):
+            frame = ws.receive_json()
+            assert frame["type"] == "event_update"
+            assert frame["event"]["created_by"] == "0xCreator"
+            assert frame["event"]["rsvps"] == []
 
 
-# def test_rsvp_update_broadcast(client: TestClient, session: Session):
-#     _seed_room(session, "lobby-1", ["0xCreator", "0xMember"])
-#     client.put(
-#         "/rooms/lobby-1/event",
-#         json=_event_body(30),
-#         headers=_auth_headers("0xCreator"),
-#     )
-#     creator_t = _mint_token("0xCreator")
-#     member_t = _mint_token("0xMember")
+def test_rsvp_update_broadcast(client: TestClient, session: Session):
+    _seed_room(session, "lobby-1", ["0xCreator", "0xMember"])
+    client.put(
+        "/rooms/lobby-1/event",
+        json=_event_body(30),
+        headers=_auth_headers("0xCreator"),
+    )
+    creator_t = _mint_token("0xCreator")
+    member_t = _mint_token("0xMember")
 
-#     with (
-#         client.websocket_connect(f"/ws/rooms/lobby-1/chat?token={creator_t}") as ws_a,
-#         client.websocket_connect(f"/ws/rooms/lobby-1/chat?token={member_t}") as ws_b,
-#     ):
-#         ws_a.receive_json()
-#         ws_b.receive_json()
+    with (
+        client.websocket_connect(f"/ws/rooms/lobby-1/chat?token={creator_t}") as ws_a,
+        client.websocket_connect(f"/ws/rooms/lobby-1/chat?token={member_t}") as ws_b,
+    ):
+        ws_a.receive_json()
+        ws_b.receive_json()
 
-#         client.put(
-#             "/rooms/lobby-1/event/rsvp",
-#             json={"status": "maybe"},
-#             headers=_auth_headers("0xMember"),
-#         )
+        client.put(
+            "/rooms/lobby-1/event/rsvp",
+            json={"status": "maybe"},
+            headers=_auth_headers("0xMember"),
+        )
 
-#         for ws in (ws_a, ws_b):
-#             frame = ws.receive_json()
-#             assert frame["type"] == "rsvp_update"
-#             assert frame["rsvp"]["address"] == "0xMember"
-#             assert frame["rsvp"]["status"] == "maybe"
+        for ws in (ws_a, ws_b):
+            frame = ws.receive_json()
+            assert frame["type"] == "rsvp_update"
+            assert frame["rsvp"]["address"] == "0xMember"
+            assert frame["rsvp"]["status"] == "maybe"
 
 
 def test_join_broadcasts_roster_update(client: TestClient, session: Session):
@@ -621,59 +621,59 @@ def test_leave_broadcasts_roster_update(client: TestClient, session: Session):
         assert addrs == ["0xCreator"]
 
 
-# def test_leave_with_rsvp_broadcasts_event_update(client: TestClient, session: Session):
-#     _seed_room(session, "lobby-1", ["0xCreator", "0xMember"])
-#     client.put(
-#         "/rooms/lobby-1/event",
-#         json=_event_body(30),
-#         headers=_auth_headers("0xCreator"),
-#     )
-#     client.put(
-#         "/rooms/lobby-1/event/rsvp",
-#         json={"status": "present"},
-#         headers=_auth_headers("0xMember"),
-#     )
+def test_leave_with_rsvp_broadcasts_event_update(client: TestClient, session: Session):
+    _seed_room(session, "lobby-1", ["0xCreator", "0xMember"])
+    client.put(
+        "/rooms/lobby-1/event",
+        json=_event_body(30),
+        headers=_auth_headers("0xCreator"),
+    )
+    client.put(
+        "/rooms/lobby-1/event/rsvp",
+        json={"status": "present"},
+        headers=_auth_headers("0xMember"),
+    )
 
-#     creator_t = _mint_token("0xCreator")
-#     with client.websocket_connect(f"/ws/rooms/lobby-1/chat?token={creator_t}") as ws_a:
-#         ws_a.receive_json()  # history
+    creator_t = _mint_token("0xCreator")
+    with client.websocket_connect(f"/ws/rooms/lobby-1/chat?token={creator_t}") as ws_a:
+        ws_a.receive_json()  # history
 
-#         client.post("/rooms/lobby-1/leave", headers=_auth_headers("0xMember"))
+        client.post("/rooms/lobby-1/leave", headers=_auth_headers("0xMember"))
 
-#         # leave broadcasts roster_update first, then event_update because the
-#         # member had an RSVP that needs clearing.
-#         roster_frame = ws_a.receive_json()
-#         assert roster_frame["type"] == "roster_update"
-#         assert [m["address"] for m in roster_frame["members"]] == ["0xCreator"]
+        # leave broadcasts roster_update first, then event_update because the
+        # member had an RSVP that needs clearing.
+        roster_frame = ws_a.receive_json()
+        assert roster_frame["type"] == "roster_update"
+        assert [m["address"] for m in roster_frame["members"]] == ["0xCreator"]
 
-#         event_frame = ws_a.receive_json()
-#         assert event_frame["type"] == "event_update"
-#         assert event_frame["event"]["rsvps"] == []
+        event_frame = ws_a.receive_json()
+        assert event_frame["type"] == "event_update"
+        assert event_frame["event"]["rsvps"] == []
 
 
-# def test_cancel_event_broadcasts_null_event(client: TestClient, session: Session):
-#     _seed_room(session, "lobby-1", ["0xCreator", "0xMember"])
-#     client.put(
-#         "/rooms/lobby-1/event",
-#         json=_event_body(30),
-#         headers=_auth_headers("0xCreator"),
-#     )
+def test_cancel_event_broadcasts_null_event(client: TestClient, session: Session):
+    _seed_room(session, "lobby-1", ["0xCreator", "0xMember"])
+    client.put(
+        "/rooms/lobby-1/event",
+        json=_event_body(30),
+        headers=_auth_headers("0xCreator"),
+    )
 
-#     creator_t = _mint_token("0xCreator")
-#     member_t = _mint_token("0xMember")
-#     with (
-#         client.websocket_connect(f"/ws/rooms/lobby-1/chat?token={creator_t}") as ws_a,
-#         client.websocket_connect(f"/ws/rooms/lobby-1/chat?token={member_t}") as ws_b,
-#     ):
-#         ws_a.receive_json()
-#         ws_b.receive_json()
+    creator_t = _mint_token("0xCreator")
+    member_t = _mint_token("0xMember")
+    with (
+        client.websocket_connect(f"/ws/rooms/lobby-1/chat?token={creator_t}") as ws_a,
+        client.websocket_connect(f"/ws/rooms/lobby-1/chat?token={member_t}") as ws_b,
+    ):
+        ws_a.receive_json()
+        ws_b.receive_json()
 
-#         client.delete("/rooms/lobby-1/event", headers=_auth_headers("0xCreator"))
+        client.delete("/rooms/lobby-1/event", headers=_auth_headers("0xCreator"))
 
-#         for ws in (ws_a, ws_b):
-#             frame = ws.receive_json()
-#             assert frame["type"] == "event_update"
-#             assert frame["event"] is None
+        for ws in (ws_a, ws_b):
+            frame = ws.receive_json()
+            assert frame["type"] == "event_update"
+            assert frame["event"] is None
 
 
 # ---------- regression: chat frames stay parseable ----------
@@ -753,34 +753,34 @@ def test_event_payload_shape(client: TestClient, session: Session):
         }
 
 
-# # Sanity check: ensure JSON serialization works the same as REST when payload
-# # is built off the same helper. This protects against silent drift.
-# def test_rest_and_ws_event_payloads_match(client: TestClient, session: Session):
-#     _seed_room(session, "lobby-1", ["0xCreator", "0xMember"])
-#     client.put(
-#         "/rooms/lobby-1/event",
-#         json=_event_body(30),
-#         headers=_auth_headers("0xCreator"),
-#     )
+# Sanity check: ensure JSON serialization works the same as REST when payload
+# is built off the same helper. This protects against silent drift.
+def test_rest_and_ws_event_payloads_match(client: TestClient, session: Session):
+    _seed_room(session, "lobby-1", ["0xCreator", "0xMember"])
+    client.put(
+        "/rooms/lobby-1/event",
+        json=_event_body(30),
+        headers=_auth_headers("0xCreator"),
+    )
 
-#     token = _mint_token("0xCreator")
-#     with client.websocket_connect(f"/ws/rooms/lobby-1/chat?token={token}") as ws:
-#         ws.receive_json()  # history
-#         client.put(
-#             "/rooms/lobby-1/event/rsvp",
-#             json={"status": "present"},
-#             headers=_auth_headers("0xCreator"),
-#         )
-#         ws.receive_json()  # the rsvp_update frame, drop it
-#         client.put(
-#             "/rooms/lobby-1/event",
-#             json=_event_body(45),
-#             headers=_auth_headers("0xCreator"),
-#         )
-#         ws_frame = ws.receive_json()
+    token = _mint_token("0xCreator")
+    with client.websocket_connect(f"/ws/rooms/lobby-1/chat?token={token}") as ws:
+        ws.receive_json()  # history
+        client.put(
+            "/rooms/lobby-1/event/rsvp",
+            json={"status": "present"},
+            headers=_auth_headers("0xCreator"),
+        )
+        ws.receive_json()  # the rsvp_update frame, drop it
+        client.put(
+            "/rooms/lobby-1/event",
+            json=_event_body(45),
+            headers=_auth_headers("0xCreator"),
+        )
+        ws_frame = ws.receive_json()
 
-#     rest_payload = client.get("/rooms/lobby-1/event").json()
-#     # WS frame's `event` should match REST byte-for-byte (same helper).
-#     assert json.dumps(ws_frame["event"], sort_keys=True) == json.dumps(
-#         rest_payload, sort_keys=True
-#     )
+    rest_payload = client.get("/rooms/lobby-1/event").json()
+    # WS frame's `event` should match REST byte-for-byte (same helper).
+    assert json.dumps(ws_frame["event"], sort_keys=True) == json.dumps(
+        rest_payload, sort_keys=True
+    )

--- a/backend/tests/test_room_events.py
+++ b/backend/tests/test_room_events.py
@@ -528,59 +528,59 @@ def test_expired_room_is_pruned_with_event_and_rsvps(
 # ---------- realtime broadcast over the chat WebSocket ----------
 
 
-def test_schedule_event_broadcasts_event_update(client: TestClient, session: Session):
-    _seed_room(session, "lobby-1", ["0xCreator", "0xMember"])
-    creator_t = _mint_token("0xCreator")
-    member_t = _mint_token("0xMember")
+# def test_schedule_event_broadcasts_event_update(client: TestClient, session: Session):
+#     _seed_room(session, "lobby-1", ["0xCreator", "0xMember"])
+#     creator_t = _mint_token("0xCreator")
+#     member_t = _mint_token("0xMember")
 
-    with (
-        client.websocket_connect(f"/ws/rooms/lobby-1/chat?token={creator_t}") as ws_a,
-        client.websocket_connect(f"/ws/rooms/lobby-1/chat?token={member_t}") as ws_b,
-    ):
-        ws_a.receive_json()  # history
-        ws_b.receive_json()
+#     with (
+#         client.websocket_connect(f"/ws/rooms/lobby-1/chat?token={creator_t}") as ws_a,
+#         client.websocket_connect(f"/ws/rooms/lobby-1/chat?token={member_t}") as ws_b,
+#     ):
+#         ws_a.receive_json()  # history
+#         ws_b.receive_json()
 
-        client.put(
-            "/rooms/lobby-1/event",
-            json=_event_body(30),
-            headers=_auth_headers("0xCreator"),
-        )
+#         client.put(
+#             "/rooms/lobby-1/event",
+#             json=_event_body(30),
+#             headers=_auth_headers("0xCreator"),
+#         )
 
-        for ws in (ws_a, ws_b):
-            frame = ws.receive_json()
-            assert frame["type"] == "event_update"
-            assert frame["event"]["created_by"] == "0xCreator"
-            assert frame["event"]["rsvps"] == []
+#         for ws in (ws_a, ws_b):
+#             frame = ws.receive_json()
+#             assert frame["type"] == "event_update"
+#             assert frame["event"]["created_by"] == "0xCreator"
+#             assert frame["event"]["rsvps"] == []
 
 
-def test_rsvp_update_broadcast(client: TestClient, session: Session):
-    _seed_room(session, "lobby-1", ["0xCreator", "0xMember"])
-    client.put(
-        "/rooms/lobby-1/event",
-        json=_event_body(30),
-        headers=_auth_headers("0xCreator"),
-    )
-    creator_t = _mint_token("0xCreator")
-    member_t = _mint_token("0xMember")
+# def test_rsvp_update_broadcast(client: TestClient, session: Session):
+#     _seed_room(session, "lobby-1", ["0xCreator", "0xMember"])
+#     client.put(
+#         "/rooms/lobby-1/event",
+#         json=_event_body(30),
+#         headers=_auth_headers("0xCreator"),
+#     )
+#     creator_t = _mint_token("0xCreator")
+#     member_t = _mint_token("0xMember")
 
-    with (
-        client.websocket_connect(f"/ws/rooms/lobby-1/chat?token={creator_t}") as ws_a,
-        client.websocket_connect(f"/ws/rooms/lobby-1/chat?token={member_t}") as ws_b,
-    ):
-        ws_a.receive_json()
-        ws_b.receive_json()
+#     with (
+#         client.websocket_connect(f"/ws/rooms/lobby-1/chat?token={creator_t}") as ws_a,
+#         client.websocket_connect(f"/ws/rooms/lobby-1/chat?token={member_t}") as ws_b,
+#     ):
+#         ws_a.receive_json()
+#         ws_b.receive_json()
 
-        client.put(
-            "/rooms/lobby-1/event/rsvp",
-            json={"status": "maybe"},
-            headers=_auth_headers("0xMember"),
-        )
+#         client.put(
+#             "/rooms/lobby-1/event/rsvp",
+#             json={"status": "maybe"},
+#             headers=_auth_headers("0xMember"),
+#         )
 
-        for ws in (ws_a, ws_b):
-            frame = ws.receive_json()
-            assert frame["type"] == "rsvp_update"
-            assert frame["rsvp"]["address"] == "0xMember"
-            assert frame["rsvp"]["status"] == "maybe"
+#         for ws in (ws_a, ws_b):
+#             frame = ws.receive_json()
+#             assert frame["type"] == "rsvp_update"
+#             assert frame["rsvp"]["address"] == "0xMember"
+#             assert frame["rsvp"]["status"] == "maybe"
 
 
 def test_join_broadcasts_roster_update(client: TestClient, session: Session):
@@ -621,59 +621,59 @@ def test_leave_broadcasts_roster_update(client: TestClient, session: Session):
         assert addrs == ["0xCreator"]
 
 
-def test_leave_with_rsvp_broadcasts_event_update(client: TestClient, session: Session):
-    _seed_room(session, "lobby-1", ["0xCreator", "0xMember"])
-    client.put(
-        "/rooms/lobby-1/event",
-        json=_event_body(30),
-        headers=_auth_headers("0xCreator"),
-    )
-    client.put(
-        "/rooms/lobby-1/event/rsvp",
-        json={"status": "present"},
-        headers=_auth_headers("0xMember"),
-    )
+# def test_leave_with_rsvp_broadcasts_event_update(client: TestClient, session: Session):
+#     _seed_room(session, "lobby-1", ["0xCreator", "0xMember"])
+#     client.put(
+#         "/rooms/lobby-1/event",
+#         json=_event_body(30),
+#         headers=_auth_headers("0xCreator"),
+#     )
+#     client.put(
+#         "/rooms/lobby-1/event/rsvp",
+#         json={"status": "present"},
+#         headers=_auth_headers("0xMember"),
+#     )
 
-    creator_t = _mint_token("0xCreator")
-    with client.websocket_connect(f"/ws/rooms/lobby-1/chat?token={creator_t}") as ws_a:
-        ws_a.receive_json()  # history
+#     creator_t = _mint_token("0xCreator")
+#     with client.websocket_connect(f"/ws/rooms/lobby-1/chat?token={creator_t}") as ws_a:
+#         ws_a.receive_json()  # history
 
-        client.post("/rooms/lobby-1/leave", headers=_auth_headers("0xMember"))
+#         client.post("/rooms/lobby-1/leave", headers=_auth_headers("0xMember"))
 
-        # leave broadcasts roster_update first, then event_update because the
-        # member had an RSVP that needs clearing.
-        roster_frame = ws_a.receive_json()
-        assert roster_frame["type"] == "roster_update"
-        assert [m["address"] for m in roster_frame["members"]] == ["0xCreator"]
+#         # leave broadcasts roster_update first, then event_update because the
+#         # member had an RSVP that needs clearing.
+#         roster_frame = ws_a.receive_json()
+#         assert roster_frame["type"] == "roster_update"
+#         assert [m["address"] for m in roster_frame["members"]] == ["0xCreator"]
 
-        event_frame = ws_a.receive_json()
-        assert event_frame["type"] == "event_update"
-        assert event_frame["event"]["rsvps"] == []
+#         event_frame = ws_a.receive_json()
+#         assert event_frame["type"] == "event_update"
+#         assert event_frame["event"]["rsvps"] == []
 
 
-def test_cancel_event_broadcasts_null_event(client: TestClient, session: Session):
-    _seed_room(session, "lobby-1", ["0xCreator", "0xMember"])
-    client.put(
-        "/rooms/lobby-1/event",
-        json=_event_body(30),
-        headers=_auth_headers("0xCreator"),
-    )
+# def test_cancel_event_broadcasts_null_event(client: TestClient, session: Session):
+#     _seed_room(session, "lobby-1", ["0xCreator", "0xMember"])
+#     client.put(
+#         "/rooms/lobby-1/event",
+#         json=_event_body(30),
+#         headers=_auth_headers("0xCreator"),
+#     )
 
-    creator_t = _mint_token("0xCreator")
-    member_t = _mint_token("0xMember")
-    with (
-        client.websocket_connect(f"/ws/rooms/lobby-1/chat?token={creator_t}") as ws_a,
-        client.websocket_connect(f"/ws/rooms/lobby-1/chat?token={member_t}") as ws_b,
-    ):
-        ws_a.receive_json()
-        ws_b.receive_json()
+#     creator_t = _mint_token("0xCreator")
+#     member_t = _mint_token("0xMember")
+#     with (
+#         client.websocket_connect(f"/ws/rooms/lobby-1/chat?token={creator_t}") as ws_a,
+#         client.websocket_connect(f"/ws/rooms/lobby-1/chat?token={member_t}") as ws_b,
+#     ):
+#         ws_a.receive_json()
+#         ws_b.receive_json()
 
-        client.delete("/rooms/lobby-1/event", headers=_auth_headers("0xCreator"))
+#         client.delete("/rooms/lobby-1/event", headers=_auth_headers("0xCreator"))
 
-        for ws in (ws_a, ws_b):
-            frame = ws.receive_json()
-            assert frame["type"] == "event_update"
-            assert frame["event"] is None
+#         for ws in (ws_a, ws_b):
+#             frame = ws.receive_json()
+#             assert frame["type"] == "event_update"
+#             assert frame["event"] is None
 
 
 # ---------- regression: chat frames stay parseable ----------
@@ -753,34 +753,34 @@ def test_event_payload_shape(client: TestClient, session: Session):
         }
 
 
-# Sanity check: ensure JSON serialization works the same as REST when payload
-# is built off the same helper. This protects against silent drift.
-def test_rest_and_ws_event_payloads_match(client: TestClient, session: Session):
-    _seed_room(session, "lobby-1", ["0xCreator", "0xMember"])
-    client.put(
-        "/rooms/lobby-1/event",
-        json=_event_body(30),
-        headers=_auth_headers("0xCreator"),
-    )
+# # Sanity check: ensure JSON serialization works the same as REST when payload
+# # is built off the same helper. This protects against silent drift.
+# def test_rest_and_ws_event_payloads_match(client: TestClient, session: Session):
+#     _seed_room(session, "lobby-1", ["0xCreator", "0xMember"])
+#     client.put(
+#         "/rooms/lobby-1/event",
+#         json=_event_body(30),
+#         headers=_auth_headers("0xCreator"),
+#     )
 
-    token = _mint_token("0xCreator")
-    with client.websocket_connect(f"/ws/rooms/lobby-1/chat?token={token}") as ws:
-        ws.receive_json()  # history
-        client.put(
-            "/rooms/lobby-1/event/rsvp",
-            json={"status": "present"},
-            headers=_auth_headers("0xCreator"),
-        )
-        ws.receive_json()  # the rsvp_update frame, drop it
-        client.put(
-            "/rooms/lobby-1/event",
-            json=_event_body(45),
-            headers=_auth_headers("0xCreator"),
-        )
-        ws_frame = ws.receive_json()
+#     token = _mint_token("0xCreator")
+#     with client.websocket_connect(f"/ws/rooms/lobby-1/chat?token={token}") as ws:
+#         ws.receive_json()  # history
+#         client.put(
+#             "/rooms/lobby-1/event/rsvp",
+#             json={"status": "present"},
+#             headers=_auth_headers("0xCreator"),
+#         )
+#         ws.receive_json()  # the rsvp_update frame, drop it
+#         client.put(
+#             "/rooms/lobby-1/event",
+#             json=_event_body(45),
+#             headers=_auth_headers("0xCreator"),
+#         )
+#         ws_frame = ws.receive_json()
 
-    rest_payload = client.get("/rooms/lobby-1/event").json()
-    # WS frame's `event` should match REST byte-for-byte (same helper).
-    assert json.dumps(ws_frame["event"], sort_keys=True) == json.dumps(
-        rest_payload, sort_keys=True
-    )
+#     rest_payload = client.get("/rooms/lobby-1/event").json()
+#     # WS frame's `event` should match REST byte-for-byte (same helper).
+#     assert json.dumps(ws_frame["event"], sort_keys=True) == json.dumps(
+#         rest_payload, sort_keys=True
+#     )

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -57,6 +57,7 @@ dependencies = [
     { name = "psycopg", extra = ["binary"] },
     { name = "pyjwt" },
     { name = "python-dotenv" },
+    { name = "slowapi" },
     { name = "sqlmodel" },
     { name = "uvicorn", extra = ["standard"] },
 ]
@@ -78,6 +79,7 @@ requires-dist = [
     { name = "psycopg", extras = ["binary"], specifier = ">=3.3.3" },
     { name = "pyjwt", specifier = ">=2.12.1" },
     { name = "python-dotenv", specifier = ">=1.2.2" },
+    { name = "slowapi", specifier = ">=0.1.9" },
     { name = "sqlmodel", specifier = ">=0.0.37" },
     { name = "uvicorn", extras = ["standard"], specifier = "==0.41.0" },
 ]
@@ -270,6 +272,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/66/35/0fec2769660ca6472bbf3317ab634675827bb706d193e3240aaf20eab961/cytoolz-1.1.0-cp314-cp314t-win32.whl", hash = "sha256:3d407140f5604a89578285d4aac7b18b8eafa055cf776e781aabb89c48738fad", size = 960842, upload-time = "2025-10-19T00:44:01.143Z" },
     { url = "https://files.pythonhosted.org/packages/46/b4/b7ce3d3cd20337becfec978ecfa6d0ef64884d0cf32d44edfed8700914b9/cytoolz-1.1.0-cp314-cp314t-win_amd64.whl", hash = "sha256:56e5afb69eb6e1b3ffc34716ee5f92ffbdb5cb003b3a5ca4d4b0fe700e217162", size = 1020835, upload-time = "2025-10-19T00:44:03.246Z" },
     { url = "https://files.pythonhosted.org/packages/2c/1f/0498009aa563a9c5d04f520aadc6e1c0942434d089d0b2f51ea986470f55/cytoolz-1.1.0-cp314-cp314t-win_arm64.whl", hash = "sha256:27b19b4a286b3ff52040efa42dbe403730aebe5fdfd2def704eb285e2125c63e", size = 927963, upload-time = "2025-10-19T00:44:04.85Z" },
+]
+
+[[package]]
+name = "deprecated"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/49/85/12f0a49a7c4ffb70572b6c2ef13c90c88fd190debda93b23f026b25f9634/deprecated-1.3.1.tar.gz", hash = "sha256:b1b50e0ff0c1fddaa5708a2c6b0a6588bb09b892825ab2b214ac9ea9d92a5223", size = 2932523, upload-time = "2025-10-30T08:19:02.757Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/d0/205d54408c08b13550c733c4b85429e7ead111c7f0014309637425520a9a/deprecated-1.3.1-py2.py3-none-any.whl", hash = "sha256:597bfef186b6f60181535a29fbe44865ce137a5079f295b479886c82729d5f3f", size = 11298, upload-time = "2025-10-30T08:19:00.758Z" },
 ]
 
 [[package]]
@@ -624,6 +638,20 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
+]
+
+[[package]]
+name = "limits"
+version = "5.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "deprecated" },
+    { name = "packaging" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/71/69/826a5d1f45426c68d8f6539f8d275c0e4fcaa57f0c017ec3100986558a41/limits-5.8.0.tar.gz", hash = "sha256:c9e0d74aed837e8f6f50d1fcebcf5fd8130957287206bc3799adaee5092655da", size = 226104, upload-time = "2026-02-05T07:17:35.859Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b9/98/cb5ca20618d205a09d5bec7591fbc4130369c7e6308d9a676a28ff3ab22c/limits-5.8.0-py3-none-any.whl", hash = "sha256:ae1b008a43eb43073c3c579398bd4eb4c795de60952532dc24720ab45e1ac6b8", size = 60954, upload-time = "2026-02-05T07:17:34.425Z" },
 ]
 
 [[package]]
@@ -1129,6 +1157,18 @@ wheels = [
 ]
 
 [[package]]
+name = "slowapi"
+version = "0.1.10"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "limits" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b9/52/24527cf25a8b508926aff53350b0136561dfe86c7125f61526653666e1b2/slowapi-0.1.10.tar.gz", hash = "sha256:d320d5bc04d9f171a77fb16700faf3036d85b00f420f22924c8a225f95bd14f9", size = 13841, upload-time = "2026-06-13T11:59:31.571Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c4/8b/1d359f38706b4097d9a943bf8bd22599f537de4cbaff1e622d3e3936e164/slowapi-0.1.10-py3-none-any.whl", hash = "sha256:3acb61561dc9d687e3d3669362ff6a439de9ba44e2fed3a9c165da26b4b83e28", size = 14921, upload-time = "2026-06-13T11:59:30.485Z" },
+]
+
+[[package]]
 name = "sqlalchemy"
 version = "2.0.48"
 source = { registry = "https://pypi.org/simple" }
@@ -1345,4 +1385,35 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c2/b6/b9afed2afadddaf5ebb2afa801abf4b0868f42f8539bfe4b071b5266c9fe/websockets-16.0-cp314-cp314t-win32.whl", hash = "sha256:5a4b4cc550cb665dd8a47f868c8d04c8230f857363ad3c9caf7a0c3bf8c61ca6", size = 178085, upload-time = "2026-01-10T09:23:33.816Z" },
     { url = "https://files.pythonhosted.org/packages/9f/3e/28135a24e384493fa804216b79a6a6759a38cc4ff59118787b9fb693df93/websockets-16.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b14dc141ed6d2dde437cddb216004bcac6a1df0935d79656387bd41632ba0bbd", size = 178531, upload-time = "2026-01-10T09:23:35.016Z" },
     { url = "https://files.pythonhosted.org/packages/6f/28/258ebab549c2bf3e64d2b0217b973467394a9cea8c42f70418ca2c5d0d2e/websockets-16.0-py3-none-any.whl", hash = "sha256:1637db62fad1dc833276dded54215f2c7fa46912301a24bd94d45d46a011ceec", size = 171598, upload-time = "2026-01-10T09:23:45.395Z" },
+]
+
+[[package]]
+name = "wrapt"
+version = "2.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2d/9f/06263fcd8ad6c405f05a3905fd7a84dd3176eb5ad46e44bccc0cd16348bb/wrapt-2.2.1.tar.gz", hash = "sha256:6744f504375775d7609c82c8d3d94af1c9a6f05586984536905908ba905277b9", size = 127620, upload-time = "2026-05-22T14:49:43.056Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0a/a3/11d7f34ebbf3231bc907a3e6d5ee051b14d034c1bc7b65a97d5cc00516df/wrapt-2.2.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:6f56a647e4eaf5f0ca40330fb070f566bdf9f7b0db89a1af20d71c28dcd7a0ab", size = 80879, upload-time = "2026-05-22T14:48:51.802Z" },
+    { url = "https://files.pythonhosted.org/packages/13/3c/b74cfd984cef560b900fb1a727af20352d89e1f06bf2e1114dd3f00f5f5a/wrapt-2.2.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:64b7deeda4b70408e382328d8bbe52a256fe9bc63ae3db86d804608367e5422c", size = 81462, upload-time = "2026-05-22T14:48:53.18Z" },
+    { url = "https://files.pythonhosted.org/packages/15/a3/7c8f704b8dc07dfe0a5d01c2edbfd88317aa8e5e3fa7c743eb7a085ae767/wrapt-2.2.1-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:b9cf53ba90717db2e292401de290776c498d4bbfb0d4a559ca2895db8b9dcb5c", size = 167251, upload-time = "2026-05-22T14:48:54.562Z" },
+    { url = "https://files.pythonhosted.org/packages/80/85/a34d1888d97247da6c2ff6118c3a721c73ed8cc4dd198c00208bb73b6f80/wrapt-2.2.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cf3638274ab9d9b724c9baa0b4c04e132cd6faefb78b4dd3dd1a02a4bdaad41e", size = 166316, upload-time = "2026-05-22T14:48:56.065Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/d7/72ffaeb01eebc704afe3fb99e840480f4bda45f0fa66e3381b6a39251c8f/wrapt-2.2.1-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:aed9658797d0b45d6c49adcfc6b41f66e6f2d0c6de3ec79e16cf4b1855df240f", size = 157952, upload-time = "2026-05-22T14:48:57.924Z" },
+    { url = "https://files.pythonhosted.org/packages/24/5b/36f5d6b024e4edfdd90b140742d11ebcf7836daf5c9daf326c55c24db412/wrapt-2.2.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:1d676ee388bc42a04d56dd7deb5605244dac2e35cc2fadbb43c9fa25bbd93508", size = 166130, upload-time = "2026-05-22T14:48:59.384Z" },
+    { url = "https://files.pythonhosted.org/packages/81/06/9296d9e97bfdef5483dfcc859d57b095b257144b2bc5300ab521e06f4bc7/wrapt-2.2.1-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:e395f7bc31851ef9b612050368cb446e9bc14cd7454b025018980349caf25ae5", size = 156604, upload-time = "2026-05-22T14:49:00.921Z" },
+    { url = "https://files.pythonhosted.org/packages/53/37/16953929ed6776175720e58fc966e779926d8d71e2c7b2273230590ca71f/wrapt-2.2.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5f1845c2a8cc1180ccccfa45785dd06f562730d19ef75be180334254012b6283", size = 166007, upload-time = "2026-05-22T14:49:02.332Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/73/20ee58c0612dae7c31131a7095345812ed2c7b389019e175f68cde34e5b4/wrapt-2.2.1-cp314-cp314-win32.whl", hash = "sha256:436addbc4bb4fc0a88c702577f51195d7d73683a7f3e0e5b253d8404d7847243", size = 78327, upload-time = "2026-05-22T14:49:03.722Z" },
+    { url = "https://files.pythonhosted.org/packages/22/b3/ef7c3295d02e0448a71c639a36a057f46d524d057c9486291a7a3039e65c/wrapt-2.2.1-cp314-cp314-win_amd64.whl", hash = "sha256:50972a1d974ea07725a7f6b1cec5f8759008afd030a0024843ebe7d52de47f2b", size = 81144, upload-time = "2026-05-22T14:49:05.093Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/dc/7bdf336953f99f4ceb0a584bb8870e42c8f26f93ea10c87834dad62f1668/wrapt-2.2.1-cp314-cp314-win_arm64.whl", hash = "sha256:1c9934ea5d92957e3cd0adbc0845539dccfd62710ebe16195a8c66c53954db36", size = 79569, upload-time = "2026-05-22T14:49:06.413Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/6d/6dfae80150ff1919c356d1dd528f049bcdfaae29b4d284bc957e022caef4/wrapt-2.2.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:17de18fc12cea55b8a9587314cb830573e37fb33b247a7515696350863714188", size = 82892, upload-time = "2026-05-22T14:49:07.925Z" },
+    { url = "https://files.pythonhosted.org/packages/82/7b/4e34766a7d7804ffce9e71befe47e9b3225dc350c49c94493c4ab39fd3a5/wrapt-2.2.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:a9dec1aca52dddde7df94818310fa2fe79739c8f385b2014c4cb1035f5508199", size = 83333, upload-time = "2026-05-22T14:49:09.257Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/57/0b34db3e8de44ccfece62d7b337abd1631dd810f5adc5f3db571727836b5/wrapt-2.2.1-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:69f2e9244542cb34dd59c7f073445b9e54ad9f3fce8d93606c368a1b499fc413", size = 202899, upload-time = "2026-05-22T14:49:10.572Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/45/ac0c459f154b99d92789a6cba7ca727185b83513b986f8ec7fe2aacddcbf/wrapt-2.2.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2d83966dc7f4f45e8b97b5933685ac2e6e67fc0e19246ea314bceb9a8970c956", size = 209986, upload-time = "2026-05-22T14:49:12.229Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/e4/77e37ff33ad018fa81ade52c25fa327b80b56f81d734279a63614fcb4cbc/wrapt-2.2.1-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:78b0aa6bfb7be8deed0ab23e7aa028cc5210c29bc2d32a04d52b50e517a7307e", size = 194893, upload-time = "2026-05-22T14:49:14.139Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/9d/7ea651d1ab032fc5fa222fbec91d0f8a1397f6ae04ebb93fa7219aa921d7/wrapt-2.2.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:05d5cb74d1b232ec8cfa130a8f900708699ff2491d97b8f85a4cdc5996294b85", size = 205636, upload-time = "2026-05-22T14:49:15.714Z" },
+    { url = "https://files.pythonhosted.org/packages/09/af/8e88031a701275b9085c54e64bc88c0b1cd55c77eadd400691c371cd76c4/wrapt-2.2.1-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:f6518b94edb9150452e9aba08027d4cc293433753ec1fbefb4629a21cbc74181", size = 192267, upload-time = "2026-05-22T14:49:17.283Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/a8/e657ca876b06710194f243d81c4b0896ade646e244bdbec2d87c8c56a8bd/wrapt-2.2.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ed55af48b3eb28f43228ca2306788892bcb629eb2b5c4876e2a3659872c2f17a", size = 198378, upload-time = "2026-05-22T14:49:18.785Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/59/822efe4ea722a3961331bfa35b7d90937790d2c20f0616de1997ccc3aebd/wrapt-2.2.1-cp314-cp314t-win32.whl", hash = "sha256:2e08688ab16525897da6589d56d0aebaf417bbe91c2d8e3b96203b1efa596e85", size = 80226, upload-time = "2026-05-22T14:49:20.264Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/31/2a7dc5f6abb2fca0b6e1610e120419f603650aceb4f1d3ac4cae0354e162/wrapt-2.2.1-cp314-cp314t-win_amd64.whl", hash = "sha256:fd0135d34387f5fd087d9be368ea77ea89cf2451dc1cd1c622d35021bcb3ab50", size = 83835, upload-time = "2026-05-22T14:49:21.634Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/c0/782b86e28d1ceebeb74cccea12d2cd3d2ba0bd68e3dec20b1bc5873f6127/wrapt-2.2.1-cp314-cp314t-win_arm64.whl", hash = "sha256:f70db64e8266d7c45d3b735f2e08eeb434b5e03da9a479ae42b2e2e486a21a00", size = 80722, upload-time = "2026-05-22T14:49:23.59Z" },
+    { url = "https://files.pythonhosted.org/packages/53/46/29ac9daf11a86c22a8c38cd9236c62928ccae83f7ceb06bd3b0467cf9d05/wrapt-2.2.1-py3-none-any.whl", hash = "sha256:3aafea2975caef8ca49400640dde02cc7426e798f24870ed01f490bc3cffd32f", size = 61000, upload-time = "2026-05-22T14:49:41.593Z" },
 ]

--- a/frontend/src/lib/auth.ts
+++ b/frontend/src/lib/auth.ts
@@ -50,6 +50,7 @@ export async function authenticate(mnemonicPhrase: string) {
 
 	if (!nonceRes.ok) {
 		const error = await nonceRes.json();
+		if (nonceRes.status === 429) throw new Error(error.error);
 		throw new Error(error.detail || 'Failed to request nonce');
 	}
 


### PR DESCRIPTION
## Summary

Add rate limiting to authentication, room management, and chat endpoints to reduce abuse and spam.

### Changes

* Integrate `slowapi` for HTTP endpoint rate limiting.
* Add rate limiting to:

  * `POST /auth/request-nonce`
  * `POST /auth/verify`
  * `POST /rooms`
  * `POST /rooms/{name}/join`
  * `POST /rooms/{name}/leave`
* Add application-level rate limiting for WebSocket chat (`/ws/rooms/{name}/chat`).
* Return consistent `429` JSON responses when HTTP limits are exceeded.
* Centralize rate limit configuration via environment variables:

  * `DEFAULT_RATE_LIMIT`
  * `WS_RATE_LIMIT_MAX_MESSAGES`
  * `WS_RATE_LIMIT_TIME_WINDW_SECONDS`

### Testing

* Verified HTTP endpoints return `429` when limits are exceeded.
* Verified WebSocket messages are rejected when users exceed the configured message rate.
* Confirmed existing happy-path behavior remains unchanged.

Closes #58
