### PR TITLE
Feat/78 kick action

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -164,11 +164,17 @@ class ConnectionManager:
         self.active_connections.append(websocket)
 
     def disconnect(self, websocket: WebSocket):
-        self.active_connections.remove(websocket)
+        if websocket in self.active_connections:
+            self.active_connections.remove(websocket)
 
     async def broadcast(self, data: str):
-        for connection in self.active_connections:
-            await connection.send_text(data)
+        for connection in list(self.active_connections):
+            try:
+                await connection.send_text(data)
+            except Exception:
+                # A stale global-list listener must not turn an already
+                # committed room mutation into an HTTP 500 response.
+                self.disconnect(connection)
 
 
 manager = ConnectionManager()
@@ -190,7 +196,12 @@ class RoomChatManager:
 
     async def broadcast(self, room: str, payload: str):
         for connection in list(self.rooms.get(room, {})):
-            await connection.send_text(payload)
+            try:
+                await connection.send_text(payload)
+            except Exception:
+                # Browsers can disappear without completing a close handshake.
+                # Drop that socket and continue updating the remaining room.
+                self.disconnect(room, connection)
 
     async def disconnect_user(self, room: str, address: str, code: int = 4409):
         """Close every room-chat connection authenticated as ``address``."""

--- a/backend/main.py
+++ b/backend/main.py
@@ -32,6 +32,7 @@ from slowapi import Limiter
 from slowapi.errors import RateLimitExceeded
 from slowapi.extension import _rate_limit_exceeded_handler
 from slowapi.util import get_remote_address
+from sqlalchemy import func
 from sqlalchemy.exc import IntegrityError
 from sqlmodel import Session, select
 
@@ -44,6 +45,7 @@ from models import (
     Room,
     RoomEvent,
     RoomEventRsvp,
+    RoomMember,
     RsvpStatus,
     User,
 )
@@ -174,24 +176,44 @@ manager = ConnectionManager()
 
 class RoomChatManager:
     def __init__(self):
-        self.rooms: dict[str, list[WebSocket]] = {}
+        self.rooms: dict[str, dict[WebSocket, str]] = {}
 
-    async def connect(self, room: str, websocket: WebSocket):
+    async def connect(self, room: str, websocket: WebSocket, address: str):
         await websocket.accept()
-        self.rooms.setdefault(room, []).append(websocket)
+        self.rooms.setdefault(room, {})[websocket] = address
 
     def disconnect(self, room: str, websocket: WebSocket):
         if room in self.rooms and websocket in self.rooms[room]:
-            self.rooms[room].remove(websocket)
+            del self.rooms[room][websocket]
             if not self.rooms[room]:
                 del self.rooms[room]
 
     async def broadcast(self, room: str, payload: str):
-        for connection in list(self.rooms.get(room, [])):
+        for connection in list(self.rooms.get(room, {})):
             await connection.send_text(payload)
+
+    async def disconnect_user(self, room: str, address: str, code: int = 4409):
+        """Close every room-chat connection authenticated as ``address``."""
+        connections = self.rooms.get(room, {})
+        targets = [
+            websocket
+            for websocket, connected_address in connections.items()
+            if connected_address.lower() == address.lower()
+        ]
+        for websocket in targets:
+            try:
+                await websocket.close(code=code)
+            except RuntimeError:
+                # The browser may have closed between the broadcast and this
+                # targeted cleanup. Its registry entry still needs removing.
+                pass
+            finally:
+                self.disconnect(room, websocket)
 
 
 chat_manager = RoomChatManager()
+
+SYSTEM_SENDER_ADDRESS = "__system__"
 
 
 # --- Helpers ---
@@ -292,10 +314,15 @@ def _iso(dt: datetime) -> str:
     return dt.isoformat() + "Z" if dt.tzinfo is None else dt.isoformat()
 
 
-def _members_payload(room: Room) -> list[dict[str, str]]:
+def _members_payload(room: Room) -> list[dict[str, str | bool]]:
     """Compact roster for chat WS `roster_update` frames."""
     return [
-        {"address": m.identity_address, "username": m.username} for m in room.members
+        {
+            "address": m.identity_address,
+            "username": m.username,
+            "is_admin": is_admin_address(m.identity_address),
+        }
+        for m in room.members
     ]
 
 
@@ -722,10 +749,7 @@ def get_room(request: Request, room_name: str, session: SessionDep):  # noqa: AR
         "players_max": room.players_max,
         "players_active": len(room.members),
         "member_addresses": [m.identity_address for m in room.members],
-        "members": [
-            {"address": m.identity_address, "username": m.username}
-            for m in room.members
-        ],
+        "members": _members_payload(room),
         "description": room.description,
         "communicator_link": room.communicator_link,
         "requirements": room.requirements,
@@ -995,6 +1019,100 @@ async def leave_room(
     return {"status": "left", "room": room.name}
 
 
+@app.post("/rooms/{room_name}/members/{member_address}/kick", status_code=200)
+@limiter.limit(DEFAULT_RATE_LIMIT)
+async def kick_room_member(
+    request: Request,  # noqa: ARG001
+    room_name: str,
+    member_address: str,
+    session: SessionDep,
+    admin_address: Annotated[str, Depends(get_admin_address)],
+):
+    """Remove a non-admin member and disconnect their active chat sessions."""
+    room = session.exec(select(Room).where(Room.name == room_name)).first()
+    if not room:
+        raise HTTPException(status_code=404, detail="Room not found")
+
+    target = session.exec(
+        select(User).where(func.lower(User.identity_address) == member_address.lower())
+    ).first()
+    if not target:
+        raise HTTPException(status_code=404, detail="User not found")
+    if is_admin_address(target.identity_address):
+        raise HTTPException(status_code=403, detail="Administrators cannot be kicked")
+    if target not in room.members:
+        raise HTTPException(status_code=409, detail="User is not a room member")
+
+    event = session.exec(select(RoomEvent).where(RoomEvent.room_id == room.id)).first()
+    if event is not None:
+        rsvp = session.exec(
+            select(RoomEventRsvp).where(
+                RoomEventRsvp.event_id == event.id,
+                RoomEventRsvp.user_id == target.id,
+            )
+        ).first()
+        if rsvp is not None:
+            session.delete(rsvp)
+
+    ownership_transferred = room.created_by.lower() == target.identity_address.lower()
+    if ownership_transferred:
+        room.created_by = admin_address
+
+    room.members.remove(target)
+    system_message = Message(
+        room_id=room.id,
+        sender_address=SYSTEM_SENDER_ADDRESS,
+        content=(f"{target.username} was removed from the room by an administrator."),
+    )
+    session.add(room)
+    session.add(system_message)
+    session.commit()
+    session.refresh(system_message)
+
+    await chat_manager.broadcast(
+        room_name,
+        json.dumps(
+            {
+                "type": "message",
+                "message": _msg_dict(system_message, "System"),
+            }
+        ),
+    )
+    await chat_manager.broadcast(
+        room_name,
+        json.dumps({"type": "roster_update", "members": _members_payload(room)}),
+    )
+    if event is not None:
+        await chat_manager.broadcast(
+            room_name,
+            json.dumps(
+                {"type": "event_update", "event": _serialize_event_state(session, room)}
+            ),
+        )
+    await chat_manager.broadcast(
+        room_name,
+        json.dumps(
+            {
+                "type": "member_kicked",
+                "member_address": target.identity_address,
+                "member_username": target.username,
+                "created_by": room.created_by,
+                "ownership_transferred": ownership_transferred,
+            }
+        ),
+    )
+    await manager.broadcast(get_rooms_payload(session))
+    await chat_manager.disconnect_user(room_name, target.identity_address)
+
+    return {
+        "status": "kicked",
+        "member_address": target.identity_address,
+        "member_username": target.username,
+        "created_by": room.created_by,
+        "ownership_transferred": ownership_transferred,
+    }
+
+
 @app.get("/rooms/{room_name}/event")
 @limiter.limit(DEFAULT_RATE_LIMIT)
 def get_room_event(request: Request, room_name: str, session: SessionDep):  # noqa: ARG001
@@ -1217,13 +1335,16 @@ async def websocket_rooms(websocket: WebSocket, session: SessionDep):
 
 
 def _msg_dict(msg: Message, sender_username: str) -> dict:
-    return {
+    payload = {
         "id": msg.id,
         "sender_address": msg.sender_address,
         "sender_username": sender_username,
         "content": msg.content,
         "created_at": _iso(msg.created_at),
     }
+    if msg.sender_address == SYSTEM_SENDER_ADDRESS:
+        payload["kind"] = "system"
+    return payload
 
 
 @app.websocket("/ws/rooms/{room_name}/chat")
@@ -1252,7 +1373,7 @@ async def websocket_chat(
         await websocket.close(code=4403)
         return
 
-    await chat_manager.connect(room_name, websocket)
+    await chat_manager.connect(room_name, websocket, address)
     try:
         # Send last 50 messages in chronological order.
         recent = session.exec(
@@ -1264,6 +1385,8 @@ async def websocket_chat(
         username_cache: dict[str, str] = {}
 
         def _username_for(addr: str) -> str:
+            if addr == SYSTEM_SENDER_ADDRESS:
+                return "System"
             cached = username_cache.get(addr)
             if cached is not None:
                 return cached
@@ -1287,6 +1410,20 @@ async def websocket_chat(
 
         while True:
             raw = await websocket.receive_text()
+
+            # Membership may have changed after the socket was accepted. Query
+            # the link table directly so a stale relationship cache cannot let
+            # a removed member continue writing to chat.
+            membership = session.exec(
+                select(RoomMember).where(
+                    RoomMember.room_id == room.id,
+                    RoomMember.user_id == user.id,
+                )
+            ).first()
+            if membership is None:
+                await websocket.close(code=4403)
+                return
+
             now = time.time()
 
             key = address

--- a/backend/main.py
+++ b/backend/main.py
@@ -889,13 +889,14 @@ async def create_room(
     if existing:
         raise HTTPException(status_code=409, detail="Room name already taken")
 
-    user_rooms_count = len(
-        session.exec(select(Room).where(Room.created_by == address)).all()
-    )
-    if user_rooms_count >= 3:
-        raise HTTPException(
-            status_code=400, detail="You can create a maximum of 3 rooms."
+    if not is_admin_address(address):
+        user_rooms_count = len(
+            session.exec(select(Room).where(Room.created_by == address)).all()
         )
+        if user_rooms_count >= 3:
+            raise HTTPException(
+                status_code=400, detail="You can create a maximum of 3 rooms."
+            )
 
     game_name = body.game.strip()
     if not game_name:

--- a/backend/tests/test_helpers.py
+++ b/backend/tests/test_helpers.py
@@ -1,7 +1,19 @@
+import asyncio
 from datetime import UTC, datetime
 
 import main
 from models import Message, Room, User
+
+
+class StubWebSocket:
+    def __init__(self, *, fails: bool = False):
+        self.fails = fails
+        self.messages: list[str] = []
+
+    async def send_text(self, payload: str):
+        if self.fails:
+            raise RuntimeError("connection is closed")
+        self.messages.append(payload)
 
 
 def test_parse_admin_addresses_trims_lowercases_and_skips_empty_values():
@@ -77,3 +89,27 @@ def test_msg_dict_keeps_public_chat_payload_shape():
         "content": "hello",
         "created_at": "2026-01-02T03:04:05+00:00",
     }
+
+
+def test_global_broadcast_drops_stale_connection_and_continues():
+    manager = main.ConnectionManager()
+    stale = StubWebSocket(fails=True)
+    healthy = StubWebSocket()
+    manager.active_connections = [stale, healthy]
+
+    asyncio.run(manager.broadcast("rooms"))
+
+    assert manager.active_connections == [healthy]
+    assert healthy.messages == ["rooms"]
+
+
+def test_room_broadcast_drops_stale_connection_and_continues():
+    manager = main.RoomChatManager()
+    stale = StubWebSocket(fails=True)
+    healthy = StubWebSocket()
+    manager.rooms = {"lobby": {stale: "0xStale", healthy: "0xHealthy"}}
+
+    asyncio.run(manager.broadcast("lobby", "roster"))
+
+    assert manager.rooms == {"lobby": {healthy: "0xHealthy"}}
+    assert healthy.messages == ["roster"]

--- a/backend/tests/test_helpers.py
+++ b/backend/tests/test_helpers.py
@@ -55,8 +55,8 @@ def test_members_payload_is_compact_roster_shape():
     )
 
     assert main._members_payload(room) == [
-        {"address": "0x1", "username": "alice"},
-        {"address": "0x2", "username": "bob"},
+        {"address": "0x1", "username": "alice", "is_admin": False},
+        {"address": "0x2", "username": "bob", "is_admin": False},
     ]
 
 

--- a/backend/tests/test_kick.py
+++ b/backend/tests/test_kick.py
@@ -200,3 +200,35 @@ def test_room_member_payload_marks_admins(
         {"address": admin_address, "username": "player_0", "is_admin": True},
         {"address": "0xMember", "username": "player_1", "is_admin": False},
     ]
+
+
+def test_admin_is_exempt_from_owned_room_limit(
+    client: TestClient, session: Session, admin_address: str
+):
+    session.add(User(identity_address=admin_address, username="admin_user"))
+    session.add_all(
+        [
+            Room(
+                name=f"owned-{index}",
+                game="Quake III Arena",
+                players_max=4,
+                created_by=admin_address,
+            )
+            for index in range(3)
+        ]
+    )
+    session.commit()
+
+    response = client.post(
+        "/rooms",
+        headers=_headers(admin_address, is_admin=True),
+        json={
+            "name": "owned-4",
+            "game": "Quake III Arena",
+            "lobby_location": "eu-central",
+            "players_max": 4,
+        },
+    )
+
+    assert response.status_code == 201
+    assert response.json() == {"status": "created", "room": "owned-4"}

--- a/backend/tests/test_kick.py
+++ b/backend/tests/test_kick.py
@@ -1,0 +1,202 @@
+import os
+from datetime import UTC, datetime, timedelta
+
+import jwt
+import pytest
+from fastapi.testclient import TestClient
+from sqlmodel import Session, select
+from starlette.websockets import WebSocketDisconnect
+
+import main
+from models import Message, Room, RoomEvent, RoomEventRsvp, User
+
+
+def _token(address: str, *, is_admin: bool = False) -> str:
+    return jwt.encode(
+        {
+            "sub": address,
+            "username": "tester",
+            "is_admin": is_admin,
+            "iat": datetime.now(UTC),
+            "exp": datetime.now(UTC) + timedelta(minutes=5),
+            "iss": "playlink-auth",
+        },
+        os.environ["JWT_SECRET"],
+        algorithm="HS256",
+    )
+
+
+def _headers(address: str, *, is_admin: bool = False) -> dict[str, str]:
+    return {"Authorization": f"Bearer {_token(address, is_admin=is_admin)}"}
+
+
+def _seed_room(session: Session, name: str, addresses: list[str]) -> Room:
+    users = [
+        User(identity_address=address, username=f"player_{index}")
+        for index, address in enumerate(addresses)
+    ]
+    session.add_all(users)
+    session.commit()
+    room = Room(
+        name=name,
+        game="Quake III Arena",
+        players_max=8,
+        created_by=addresses[0],
+    )
+    room.members.extend(users)
+    session.add(room)
+    session.commit()
+    session.refresh(room)
+    return room
+
+
+@pytest.fixture
+def admin_address():
+    address = "0xAdmin"
+    main.ADMIN_ADDRESSES.add(address.lower())
+    try:
+        yield address
+    finally:
+        main.ADMIN_ADDRESSES.discard(address.lower())
+
+
+def test_kick_requires_admin(client: TestClient, session: Session):
+    _seed_room(session, "lobby", ["0xOwner", "0xMember"])
+
+    unauthenticated = client.post("/rooms/lobby/members/0xMember/kick")
+    regular = client.post(
+        "/rooms/lobby/members/0xMember/kick", headers=_headers("0xOwner")
+    )
+
+    assert unauthenticated.status_code == 401
+    assert regular.status_code == 403
+
+
+def test_admin_cannot_kick_an_admin(
+    client: TestClient, session: Session, admin_address: str
+):
+    other_admin = "0xOtherAdmin"
+    main.ADMIN_ADDRESSES.add(other_admin.lower())
+    try:
+        _seed_room(session, "lobby", [admin_address, other_admin])
+        response = client.post(
+            f"/rooms/lobby/members/{other_admin}/kick",
+            headers=_headers(admin_address, is_admin=True),
+        )
+    finally:
+        main.ADMIN_ADDRESSES.discard(other_admin.lower())
+
+    assert response.status_code == 403
+    assert response.json()["detail"] == "Administrators cannot be kicked"
+
+
+def test_kick_removes_member_rsvp_and_allows_rejoin(
+    client: TestClient, session: Session, admin_address: str
+):
+    target_address = "0xTarget"
+    room = _seed_room(session, "lobby", [admin_address, target_address])
+    target = session.exec(
+        select(User).where(User.identity_address == target_address)
+    ).one()
+    event = RoomEvent(
+        room_id=room.id,
+        starts_at=datetime.now(UTC) + timedelta(hours=1),
+        ends_at=datetime.now(UTC) + timedelta(hours=2),
+        created_by=admin_address,
+    )
+    session.add(event)
+    session.commit()
+    session.refresh(event)
+    session.add(RoomEventRsvp(event_id=event.id, user_id=target.id, status="present"))
+    session.commit()
+
+    response = client.post(
+        f"/rooms/lobby/members/{target_address.lower()}/kick",
+        headers=_headers(admin_address, is_admin=True),
+    )
+
+    assert response.status_code == 200
+    assert response.json()["member_address"] == target_address
+    session.refresh(room)
+    assert [member.identity_address for member in room.members] == [admin_address]
+    assert session.exec(select(RoomEventRsvp)).all() == []
+    system_message = session.exec(select(Message)).one()
+    assert system_message.sender_address == main.SYSTEM_SENDER_ADDRESS
+    assert system_message.content == (
+        "player_1 was removed from the room by an administrator."
+    )
+
+    rejoin = client.post("/rooms/lobby/join", headers=_headers(target_address))
+    assert rejoin.status_code == 200
+    assert rejoin.json()["status"] == "joined"
+
+    with client.websocket_connect(
+        f"/ws/rooms/lobby/chat?token={_token(target_address)}"
+    ) as websocket:
+        history = websocket.receive_json()
+        assert history["messages"][0]["kind"] == "system"
+
+
+def test_kicking_creator_transfers_ownership_without_restoring_it_on_rejoin(
+    client: TestClient, session: Session, admin_address: str
+):
+    creator = "0xCreator"
+    room = _seed_room(session, "lobby", [creator, admin_address])
+
+    response = client.post(
+        f"/rooms/lobby/members/{creator}/kick",
+        headers=_headers(admin_address, is_admin=True),
+    )
+
+    assert response.status_code == 200
+    assert response.json()["ownership_transferred"] is True
+    assert response.json()["created_by"] == admin_address
+    session.refresh(room)
+    assert room.created_by == admin_address
+
+    rejoin = client.post("/rooms/lobby/join", headers=_headers(creator))
+    assert rejoin.status_code == 200
+    session.refresh(room)
+    assert room.created_by == admin_address
+
+
+def test_kick_notifies_and_disconnects_active_socket(
+    client: TestClient, session: Session, admin_address: str
+):
+    target = "0xTarget"
+    _seed_room(session, "lobby", [admin_address, target])
+
+    websocket_url = f"/ws/rooms/lobby/chat?token={_token(target)}"
+    with (
+        client.websocket_connect(websocket_url) as first_socket,
+        client.websocket_connect(websocket_url) as second_socket,
+    ):
+        assert first_socket.receive_json()["type"] == "history"
+        assert second_socket.receive_json()["type"] == "history"
+        response = client.post(
+            f"/rooms/lobby/members/{target}/kick",
+            headers=_headers(admin_address, is_admin=True),
+        )
+        assert response.status_code == 200
+        for websocket in (first_socket, second_socket):
+            assert websocket.receive_json()["message"]["kind"] == "system"
+            assert websocket.receive_json()["type"] == "roster_update"
+            kicked = websocket.receive_json()
+            assert kicked["type"] == "member_kicked"
+            assert kicked["member_address"] == target
+            with pytest.raises(WebSocketDisconnect) as exc:
+                websocket.receive_json()
+            assert exc.value.code == 4409
+
+
+def test_room_member_payload_marks_admins(
+    client: TestClient, session: Session, admin_address: str
+):
+    _seed_room(session, "lobby", [admin_address, "0xMember"])
+
+    members = client.get("/rooms/lobby").json()["members"]
+
+    assert members == [
+        {"address": admin_address, "username": "player_0", "is_admin": True},
+        {"address": "0xMember", "username": "player_1", "is_admin": False},
+    ]

--- a/frontend/src/lib/chatStore.ts
+++ b/frontend/src/lib/chatStore.ts
@@ -301,7 +301,7 @@ export function createChatStore(
 		};
 
 		ws.onclose = (event) => {
-			if (event.code === 4409) {
+			if (event.code === 4403 || event.code === 4409) {
 				kicked.set(true);
 				isTornDown = true;
 				if (reconnectTimeout) clearTimeout(reconnectTimeout);

--- a/frontend/src/lib/chatStore.ts
+++ b/frontend/src/lib/chatStore.ts
@@ -10,11 +10,13 @@ export interface ChatMessage {
 	sender_username: string;
 	content: string;
 	created_at: string;
+	kind?: 'user' | 'system';
 }
 
 export interface RoomMember {
 	address: string;
 	username: string;
+	is_admin: boolean;
 }
 
 export type RsvpStatus = 'present' | 'absent' | 'maybe';
@@ -67,13 +69,22 @@ interface RoomClosedFrame {
 	room: string;
 }
 
+interface MemberKickedFrame {
+	type: 'member_kicked';
+	member_address: string;
+	member_username: string;
+	created_by: string;
+	ownership_transferred: boolean;
+}
+
 type ChatFrame =
 	| HistoryFrame
 	| MessageFrame
 	| EventUpdateFrame
 	| RsvpUpdateFrame
 	| RosterUpdateFrame
-	| RoomClosedFrame;
+	| RoomClosedFrame
+	| MemberKickedFrame;
 
 // ---------- Frame validation ----------
 
@@ -85,14 +96,19 @@ function isChatMessage(value: unknown): value is ChatMessage {
 		typeof m.sender_address === 'string' &&
 		typeof m.sender_username === 'string' &&
 		typeof m.content === 'string' &&
-		typeof m.created_at === 'string'
+		typeof m.created_at === 'string' &&
+		(m.kind === undefined || m.kind === 'user' || m.kind === 'system')
 	);
 }
 
 function isRoomMember(value: unknown): value is RoomMember {
 	if (typeof value !== 'object' || value === null) return false;
 	const m = value as Record<string, unknown>;
-	return typeof m.address === 'string' && typeof m.username === 'string';
+	return (
+		typeof m.address === 'string' &&
+		typeof m.username === 'string' &&
+		typeof m.is_admin === 'boolean'
+	);
 }
 
 function isRsvpStatus(value: unknown): value is RsvpStatus {
@@ -154,6 +170,15 @@ function parseFrame(raw: string): ChatFrame | null {
 	if (f.type === 'room_closed' && typeof f.room === 'string') {
 		return { type: 'room_closed', room: f.room };
 	}
+	if (
+		f.type === 'member_kicked' &&
+		typeof f.member_address === 'string' &&
+		typeof f.member_username === 'string' &&
+		typeof f.created_by === 'string' &&
+		typeof f.ownership_transferred === 'boolean'
+	) {
+		return f as unknown as MemberKickedFrame;
+	}
 	return null;
 }
 
@@ -168,6 +193,10 @@ export interface ChatStore {
 	members: Readable<RoomMember[]>;
 	/** Becomes `true` when an admin closes the room (`room_closed` frame). */
 	closed: Readable<boolean>;
+	/** Current room owner, updated after creator kicks. */
+	owner: Readable<string>;
+	/** Becomes `true` when this client is removed from the room. */
+	kicked: Readable<boolean>;
 	send(content: string): void;
 	destroy(): void;
 }
@@ -177,6 +206,10 @@ export interface CreateChatStoreOptions {
 	initialEvent?: RoomEventState | null;
 	/** Initial member roster from SSR, used until the first WS update. */
 	initialMembers?: RoomMember[];
+	/** Initial room owner from SSR. */
+	initialOwner?: string;
+	/** Address represented by this browser session. */
+	currentAddress?: string;
 }
 
 export function createChatStore(
@@ -188,6 +221,8 @@ export function createChatStore(
 	const event = writable<RoomEventState | null>(options.initialEvent ?? null);
 	const members = writable<RoomMember[]>(options.initialMembers ?? []);
 	const closed = writable<boolean>(false);
+	const owner = writable<string>(options.initialOwner ?? '');
+	const kicked = writable<boolean>(false);
 
 	let ws: WebSocket | null = null;
 	let reconnectTimeout: ReturnType<typeof setTimeout> | null = null;
@@ -251,10 +286,27 @@ export function createChatStore(
 					if (reconnectTimeout) clearTimeout(reconnectTimeout);
 					ws?.close();
 					break;
+				case 'member_kicked':
+					owner.set(frame.created_by);
+					if (
+						options.currentAddress &&
+						frame.member_address.toLowerCase() === options.currentAddress.toLowerCase()
+					) {
+						kicked.set(true);
+						isTornDown = true;
+						if (reconnectTimeout) clearTimeout(reconnectTimeout);
+					}
+					break;
 			}
 		};
 
-		ws.onclose = () => {
+		ws.onclose = (event) => {
+			if (event.code === 4409) {
+				kicked.set(true);
+				isTornDown = true;
+				if (reconnectTimeout) clearTimeout(reconnectTimeout);
+				return;
+			}
 			scheduleReconnect();
 		};
 
@@ -281,6 +333,8 @@ export function createChatStore(
 		event: { subscribe: event.subscribe },
 		members: { subscribe: members.subscribe },
 		closed: { subscribe: closed.subscribe },
+		owner: { subscribe: owner.subscribe },
+		kicked: { subscribe: kicked.subscribe },
 		send(content: string) {
 			const trimmed = content.trim();
 			if (!trimmed || !ws || ws.readyState !== WebSocket.OPEN) return;

--- a/frontend/src/routes/rooms/+page.svelte
+++ b/frontend/src/routes/rooms/+page.svelte
@@ -388,7 +388,7 @@
 			}
 			if (e.key === 'Enter' && selectedRoom && data.isAuthenticated && data.user) {
 				const isMember = selectedRoom.member_addresses.includes(data.user.address);
-				if (isMember) {
+				if (isMember || data.isAdmin) {
 					e.preventDefault();
 					goto(`/rooms/${encodeURIComponent(selectedRoom.name)}`);
 				}
@@ -601,6 +601,15 @@
 									href="/rooms/{encodeURIComponent(room.name)}"
 								>
 									Open
+								</OrnateButton>
+							{:else if data.isAdmin}
+								<OrnateButton
+									variant="secondary"
+									size="md"
+									fullWidth
+									href="/rooms/{encodeURIComponent(room.name)}"
+								>
+									Admin Preview
 								</OrnateButton>
 							{/if}
 

--- a/frontend/src/routes/rooms/+page.svelte
+++ b/frontend/src/routes/rooms/+page.svelte
@@ -974,14 +974,65 @@
 			position: sticky;
 			top: 0;
 			align-self: start;
-			max-height: calc(100vh - 8rem);
-			overflow: auto;
+			max-height: none;
+			overflow: visible;
+		}
+
+		.create-fab {
+			display: grid;
+			grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+			gap: 0.55rem;
+			margin-bottom: 0.65rem;
+		}
+
+		.side-col :global(.inner-panel .panel-body) {
+			padding: 0.9rem 1.15rem;
+		}
+
+		.side-col :global(.section-title) {
+			margin-bottom: 0.55rem;
+		}
+
+		.side-col .filter-group {
+			gap: 0.3rem;
+			margin-bottom: 0.65rem;
+		}
+
+		.side-col .filter-actions,
+		.side-col .name-filter {
+			margin-bottom: 0.7rem;
+		}
+
+		.side-col .text-input {
+			padding: 0.5rem 0.7rem;
+		}
+
+		.side-col .stats {
+			gap: 0.5rem;
+			padding-top: 0.2rem;
+		}
+
+		.side-col .stat {
+			padding: 0.4rem 0.6rem;
 		}
 	}
 
 	.list-col {
 		display: flex;
 		min-height: 0;
+	}
+
+	/* The filter/details rail still scrolls on short viewports, but the native
+	   browser scrollbar clashes with the framed UI and steals horizontal space. */
+	.side-col {
+		scrollbar-width: none;
+		-ms-overflow-style: none;
+	}
+
+	.side-col::-webkit-scrollbar {
+		display: none;
+		width: 0;
+		height: 0;
 	}
 
 	.list-col :global(.inner-panel) {

--- a/frontend/src/routes/rooms/[name]/+page.server.ts
+++ b/frontend/src/routes/rooms/[name]/+page.server.ts
@@ -66,7 +66,7 @@ export const load: PageServerLoad = async ({ params, cookies }) => {
 
 	const lower = address.toLowerCase();
 	const isMember = roomDetail.member_addresses.some((a) => a.toLowerCase() === lower);
-	if (!isMember) {
+	if (!isMember && !isAdmin) {
 		throw redirect(303, '/rooms');
 	}
 
@@ -85,6 +85,8 @@ export const load: PageServerLoad = async ({ params, cookies }) => {
 		members: roomDetail.members,
 		event: roomDetail.event,
 		isAdmin,
+		isMember,
+		isPreview: isAdmin && !isMember,
 		createdBy: roomDetail.created_by,
 		isCreator: roomDetail.created_by.toLowerCase() === lower
 	};
@@ -103,6 +105,26 @@ function localInputToIsoUtc(value: string): string | null {
 }
 
 export const actions: Actions = {
+	closeRoom: async ({ cookies, params }) => {
+		const session = cookies.get('session');
+		if (!session) return fail(401, { error: 'Not authenticated' });
+
+		const baseUrl = backendBase();
+		try {
+			const res = await fetch(`${baseUrl}/rooms/${encodeURIComponent(params.name)}`, {
+				method: 'DELETE',
+				headers: { Authorization: `Bearer ${session}` }
+			});
+			if (!res.ok) {
+				const result = await res.json().catch(() => ({}));
+				return fail(res.status, { error: result.detail || 'Failed to close room' });
+			}
+			return { success: true, closed: true };
+		} catch {
+			return fail(500, { error: 'Server error' });
+		}
+	},
+
 	kickMember: async ({ request, cookies, params }) => {
 		const session = cookies.get('session');
 		if (!session) return fail(401, { error: 'Not authenticated' });

--- a/frontend/src/routes/rooms/[name]/+page.server.ts
+++ b/frontend/src/routes/rooms/[name]/+page.server.ts
@@ -4,7 +4,7 @@ import { env as privateEnv } from '$env/dynamic/private';
 import { fail, redirect } from '@sveltejs/kit';
 import { jwtDecode } from 'jwt-decode';
 import { lobbyLocationLabel, FALLBACK_LOBBY_LOCATIONS } from '$lib/lobbyLocations';
-import type { RoomEventState } from '$lib/chatStore';
+import type { RoomEventState, RoomMember } from '$lib/chatStore';
 
 function backendBase(): string {
 	return privateEnv.BACKEND_INTERNAL_URL || env.PUBLIC_BACKEND_URL || 'http://localhost:8000';
@@ -13,6 +13,7 @@ function backendBase(): string {
 interface SessionTokenClaims {
 	sub?: string;
 	username?: string;
+	is_admin?: boolean;
 }
 
 interface RoomDetail {
@@ -22,7 +23,7 @@ interface RoomDetail {
 	players_max: number;
 	players_active: number;
 	member_addresses: string[];
-	members: { address: string; username: string }[];
+	members: RoomMember[];
 	description: string | null;
 	communicator_link: string | null;
 	requirements: string | null;
@@ -37,10 +38,12 @@ export const load: PageServerLoad = async ({ params, cookies }) => {
 
 	let address: string | null = null;
 	let username = 'Unknown';
+	let isAdmin = false;
 	try {
 		const claims = jwtDecode<SessionTokenClaims>(session);
 		if (claims?.sub) address = claims.sub;
 		if (claims?.username) username = claims.username;
+		isAdmin = claims?.is_admin === true;
 	} catch {
 		throw redirect(303, '/auth');
 	}
@@ -81,6 +84,8 @@ export const load: PageServerLoad = async ({ params, cookies }) => {
 		memberAddresses: roomDetail.member_addresses,
 		members: roomDetail.members,
 		event: roomDetail.event,
+		isAdmin,
+		createdBy: roomDetail.created_by,
 		isCreator: roomDetail.created_by.toLowerCase() === lower
 	};
 };
@@ -98,6 +103,35 @@ function localInputToIsoUtc(value: string): string | null {
 }
 
 export const actions: Actions = {
+	kickMember: async ({ request, cookies, params }) => {
+		const session = cookies.get('session');
+		if (!session) return fail(401, { error: 'Not authenticated' });
+
+		const data = await request.formData();
+		const memberAddress = data.get('member_address');
+		if (typeof memberAddress !== 'string' || !memberAddress) {
+			return fail(400, { error: 'Missing member address' });
+		}
+
+		const baseUrl = backendBase();
+		try {
+			const res = await fetch(
+				`${baseUrl}/rooms/${encodeURIComponent(params.name)}/members/${encodeURIComponent(memberAddress)}/kick`,
+				{
+					method: 'POST',
+					headers: { Authorization: `Bearer ${session}` }
+				}
+			);
+			const result = await res.json().catch(() => ({}));
+			if (!res.ok) {
+				return fail(res.status, { error: result.detail || 'Failed to kick player' });
+			}
+			return { success: true, kick: result };
+		} catch {
+			return fail(500, { error: 'Server error' });
+		}
+	},
+
 	scheduleEvent: async ({ request, cookies, params }) => {
 		const session = cookies.get('session');
 		if (!session) return fail(401, { error: 'Not authenticated' });

--- a/frontend/src/routes/rooms/[name]/+page.svelte
+++ b/frontend/src/routes/rooms/[name]/+page.svelte
@@ -465,7 +465,7 @@
 		closeable={false}
 		width="460px"
 	>
-		<p class="closed-text">An administrator removed you from this room.</p>
+		<p class="closed-text">You are no longer a member of this room.</p>
 		<p class="closed-sub">
 			You may join again. Returning to the rooms list in {redirectIn}
 			{redirectIn === 1 ? 'second' : 'seconds'}…

--- a/frontend/src/routes/rooms/[name]/+page.svelte
+++ b/frontend/src/routes/rooms/[name]/+page.svelte
@@ -39,6 +39,9 @@
 	let kickTarget = $state<PartyMember | null>(null);
 	let kickPending = $state(false);
 	let kickError = $state<string | null>(null);
+	let closeConfirm = $state(false);
+	let closePending = $state(false);
+	let closeError = $state<string | null>(null);
 
 	function leaveClosedRoom() {
 		goto('/rooms');
@@ -47,14 +50,19 @@
 	const hintsState = getHintsState();
 
 	$effect(() => {
-		hintsState?.set([
-			{ key: 'Enter', label: 'Transmit', tone: 'gold' },
-			{ key: '⇧Enter', label: 'Newline', tone: 'stone' },
-			{ key: 'Esc', label: 'Leave', tone: 'red' }
-		]);
+		hintsState?.set(
+			data.isPreview
+				? [{ key: 'Esc', label: 'Back to Rooms', tone: 'red' }]
+				: [
+						{ key: 'Enter', label: 'Transmit', tone: 'gold' },
+						{ key: '⇧Enter', label: 'Newline', tone: 'stone' },
+						{ key: 'Esc', label: 'Leave', tone: 'red' }
+					]
+		);
 	});
 
 	onMount(() => {
+		if (!data.isMember) return;
 		const store = createChatStore(data.roomName, data.token, {
 			initialEvent: data.event,
 			initialMembers: data.members,
@@ -179,10 +187,27 @@
 		try {
 			const response = await fetch('?/kickMember', { method: 'POST', body });
 			const result = deserialize(await response.text()) as
-				| { type: 'success' }
+				| {
+						type: 'success';
+						data?: { kick?: { created_by?: string } };
+				  }
 				| { type: 'failure'; data?: { error?: string } }
 				| { type: 'error' | 'redirect' };
 			if (result.type === 'success') {
+				roster = roster.filter(
+					(item) => item.address.toLowerCase() !== member.address.toLowerCase()
+				);
+				if (event) {
+					event = {
+						...event,
+						rsvps: event.rsvps.filter(
+							(rsvp) => rsvp.address.toLowerCase() !== member.address.toLowerCase()
+						)
+					};
+				}
+				if (result.data?.kick?.created_by) {
+					ownerAddress = result.data.kick.created_by;
+				}
 				kickTarget = null;
 			} else if (result.type === 'failure') {
 				kickError = result.data?.error ?? 'Failed to kick player';
@@ -193,6 +218,30 @@
 			kickError = 'Server error';
 		} finally {
 			kickPending = false;
+		}
+	}
+
+	async function closeRoom() {
+		if (closePending) return;
+		closePending = true;
+		closeError = null;
+		try {
+			const response = await fetch('?/closeRoom', { method: 'POST' });
+			const result = deserialize(await response.text()) as
+				| { type: 'success' }
+				| { type: 'failure'; data?: { error?: string } }
+				| { type: 'error' | 'redirect' };
+			if (result.type === 'success') {
+				await goto('/rooms');
+			} else if (result.type === 'failure') {
+				closeError = result.data?.error ?? 'Failed to close room';
+			} else {
+				closeError = 'Failed to close room';
+			}
+		} catch {
+			closeError = 'Server error';
+		} finally {
+			closePending = false;
 		}
 	}
 </script>
@@ -247,6 +296,9 @@
 					<div class="head-row top-row">
 						<a class="back small-caps" href="/rooms">◄ Rooms</a>
 						<div class="shard">
+							{#if data.isPreview}
+								<span class="preview-badge small-caps">Admin Preview</span>
+							{/if}
 							<span class="shard-label small-caps">Shard Hash</span>
 							<span class="shard-hash">{shortAddr(data.address)}</span>
 						</div>
@@ -305,78 +357,100 @@
 					<RoomEvent
 						{event}
 						isCreator={ownerAddress.toLowerCase() === data.address.toLowerCase()}
-						isMember={true}
+						isMember={data.isMember}
 						viewerAddress={data.address}
 						members={eventMembers}
 						formError={form?.error ?? null}
 					/>
 				</div>
 
-				<div class="chat-wrap">
-					<div class="chat scroll-d2 bevel-in" bind:this={scroller}>
-						<div class="chat-noise" aria-hidden="true"></div>
-						{#if messages.length === 0}
-							<div class="empty">
-								<Crest size={56} tone="iron" />
-								<p>The void is silent. Speak first.</p>
-							</div>
-						{:else}
-							<ul class="msg-list">
-								{#each messages as msg (msg.id)}
-									{@const system = msg.kind === 'system'}
-									{@const mine = !system && isMine(msg.sender_address)}
-									<li class="msg-row" class:mine class:other={!mine && !system} class:system>
-										<article class="msg" class:mine class:other={!mine && !system} class:system>
-											<div class="msg-meta">
-												<span class="sender small-caps">
-													{system
-														? 'System'
-														: mine
-															? 'You'
-															: msg.sender_username || shortAddr(msg.sender_address)}
-												</span>
-												{#if !system}
-													<span class="sep" aria-hidden="true">·</span>
-													<span class="addr">{shortAddr(msg.sender_address)}</span>
-												{/if}
-												<span class="sep" aria-hidden="true">·</span>
-												<span class="time">{fmtTime(msg.created_at)}</span>
-											</div>
-											<div class="content">{msg.content}</div>
-										</article>
-									</li>
-								{/each}
-							</ul>
-						{/if}
-					</div>
-
-					<form
-						class="composer"
-						onsubmit={(e) => {
-							e.preventDefault();
-							send();
-						}}
-					>
-						<input
-							class="msg-input bevel-in"
-							type="text"
-							bind:value={input}
-							onkeydown={onKey}
-							placeholder={closed ? 'Room closed' : kicked ? 'Removed from room' : 'Speak…'}
-							maxlength={1000}
-							autocomplete="off"
-							disabled={closed || kicked}
-						/>
+				{#if data.isPreview}
+					<div class="admin-preview bevel-in">
+						<Crest size={56} tone="iron" />
+						<p class="preview-title small-caps">Administrative Preview</p>
+						<p class="preview-copy">
+							You are viewing this room without joining it. Chat and RSVP actions are unavailable,
+							and no player slot is occupied.
+						</p>
 						<OrnateButton
-							type="submit"
-							variant="primary"
+							variant="danger"
 							size="md"
-							disabled={closed || kicked || !input.trim()}
+							disabled={closePending}
+							onclick={() => {
+								closeError = null;
+								closeConfirm = true;
+							}}
 						>
-							Transmit
+							Close Room
 						</OrnateButton>
-					</form>
-				</div>
+					</div>
+				{:else}
+					<div class="chat-wrap">
+						<div class="chat scroll-d2 bevel-in" bind:this={scroller}>
+							<div class="chat-noise" aria-hidden="true"></div>
+							{#if messages.length === 0}
+								<div class="empty">
+									<Crest size={56} tone="iron" />
+									<p>The void is silent. Speak first.</p>
+								</div>
+							{:else}
+								<ul class="msg-list">
+									{#each messages as msg (msg.id)}
+										{@const system = msg.kind === 'system'}
+										{@const mine = !system && isMine(msg.sender_address)}
+										<li class="msg-row" class:mine class:other={!mine && !system} class:system>
+											<article class="msg" class:mine class:other={!mine && !system} class:system>
+												<div class="msg-meta">
+													<span class="sender small-caps">
+														{system
+															? 'System'
+															: mine
+																? 'You'
+																: msg.sender_username || shortAddr(msg.sender_address)}
+													</span>
+													{#if !system}
+														<span class="sep" aria-hidden="true">·</span>
+														<span class="addr">{shortAddr(msg.sender_address)}</span>
+													{/if}
+													<span class="sep" aria-hidden="true">·</span>
+													<span class="time">{fmtTime(msg.created_at)}</span>
+												</div>
+												<div class="content">{msg.content}</div>
+											</article>
+										</li>
+									{/each}
+								</ul>
+							{/if}
+						</div>
+
+						<form
+							class="composer"
+							onsubmit={(e) => {
+								e.preventDefault();
+								send();
+							}}
+						>
+							<input
+								class="msg-input bevel-in"
+								type="text"
+								bind:value={input}
+								onkeydown={onKey}
+								placeholder={closed ? 'Room closed' : kicked ? 'Removed from room' : 'Speak…'}
+								maxlength={1000}
+								autocomplete="off"
+								disabled={closed || kicked}
+							/>
+							<OrnateButton
+								type="submit"
+								variant="primary"
+								size="md"
+								disabled={closed || kicked || !input.trim()}
+							>
+								Transmit
+							</OrnateButton>
+						</form>
+					</div>
+				{/if}
 			</div>
 		</InnerPanel>
 	</div>
@@ -463,6 +537,40 @@
 				onclick={() => kickMember(target)}
 			>
 				{kickPending ? 'Kicking…' : 'Kick Player'}
+			</OrnateButton>
+		{/snippet}
+	</SystemDialog>
+{/if}
+
+{#if closeConfirm}
+	<SystemDialog
+		open={true}
+		title="Close Room"
+		tone="blood"
+		modal
+		width="460px"
+		onclose={() => {
+			if (!closePending) closeConfirm = false;
+		}}
+	>
+		<p class="closed-text">
+			Close <strong>{data.roomName}</strong>? This deletes its chat, scheduled event and all RSVPs,
+			and disconnects everyone inside. This cannot be undone.
+		</p>
+		{#if closeError}
+			<p class="kick-error" role="alert">{closeError}</p>
+		{/if}
+		{#snippet footer()}
+			<OrnateButton
+				variant="ghost"
+				size="md"
+				disabled={closePending}
+				onclick={() => (closeConfirm = false)}
+			>
+				Cancel
+			</OrnateButton>
+			<OrnateButton variant="danger" size="md" disabled={closePending} onclick={closeRoom}>
+				{closePending ? 'Closing…' : 'Close Room'}
 			</OrnateButton>
 		{/snippet}
 	</SystemDialog>
@@ -646,6 +754,16 @@
 		letter-spacing: var(--track-loose);
 	}
 
+	.preview-badge {
+		padding: 0.18rem 0.45rem;
+		border: 1px solid var(--blood);
+		background: rgba(120, 18, 18, 0.16);
+		color: var(--blood-bright);
+		font-family: var(--font-display);
+		font-size: 0.62rem;
+		letter-spacing: var(--track-loose);
+	}
+
 	.shard-hash {
 		font-family: var(--font-mono);
 		font-size: 0.72rem;
@@ -757,6 +875,36 @@
 		gap: 0.75rem;
 		flex: 1;
 		min-height: 0;
+	}
+
+	.admin-preview {
+		flex: 1;
+		min-height: 220px;
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		justify-content: center;
+		gap: 0.75rem;
+		padding: 1.5rem;
+		text-align: center;
+		background: linear-gradient(180deg, var(--stone-2) 0%, var(--stone-1) 100%);
+	}
+
+	.preview-title {
+		margin: 0;
+		color: var(--gold-base);
+		font-family: var(--font-display);
+		font-size: 0.9rem;
+		letter-spacing: var(--track-loose);
+	}
+
+	.preview-copy {
+		max-width: 560px;
+		margin: 0 0 0.35rem;
+		color: var(--bone-muted);
+		font-family: var(--font-display);
+		font-size: 0.86rem;
+		line-height: 1.55;
 	}
 
 	.chat {

--- a/frontend/src/routes/rooms/[name]/+page.svelte
+++ b/frontend/src/routes/rooms/[name]/+page.svelte
@@ -61,6 +61,16 @@
 		);
 	});
 
+	// Members receive event/roster changes over the room WebSocket. Admin Preview
+	// deliberately has no socket, so synchronize its local state after enhanced
+	// form actions invalidate and reload the page data.
+	$effect(() => {
+		if (!data.isPreview) return;
+		event = data.event;
+		roster = data.members;
+		ownerAddress = data.createdBy;
+	});
+
 	onMount(() => {
 		if (!data.isMember) return;
 		const store = createChatStore(data.roomName, data.token, {

--- a/frontend/src/routes/rooms/[name]/+page.svelte
+++ b/frontend/src/routes/rooms/[name]/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { onDestroy, onMount, tick, untrack } from 'svelte';
 	import { goto } from '$app/navigation';
+	import { deserialize } from '$app/forms';
 	import type { PageData } from './$types';
 	import {
 		createChatStore,
@@ -26,13 +27,18 @@
 	let messages = $state<ChatMessage[]>([]);
 	let event = $state<RoomEventState | null>(untrack(() => data.event));
 	let roster = $state<RoomMember[]>(untrack(() => data.members));
+	let ownerAddress = $state(untrack(() => data.createdBy));
 	let input = $state('');
 	let scroller: HTMLDivElement | null = $state(null);
 
 	// Set when an admin closes the room; freezes the UI and counts down to a
 	// redirect back to the rooms list.
 	let closed = $state(false);
+	let kicked = $state(false);
 	let redirectIn = $state(CLOSE_REDIRECT_SECONDS);
+	let kickTarget = $state<PartyMember | null>(null);
+	let kickPending = $state(false);
+	let kickError = $state<string | null>(null);
 
 	function leaveClosedRoom() {
 		goto('/rooms');
@@ -51,7 +57,9 @@
 	onMount(() => {
 		const store = createChatStore(data.roomName, data.token, {
 			initialEvent: data.event,
-			initialMembers: data.members
+			initialMembers: data.members,
+			initialOwner: data.createdBy,
+			currentAddress: data.address
 		});
 		chat = store;
 		const unsubMessages = store.messages.subscribe(async (m) => {
@@ -65,22 +73,38 @@
 		const unsubMembers = store.members.subscribe((m) => {
 			roster = m;
 		});
+		const unsubOwner = store.owner.subscribe((address) => {
+			ownerAddress = address;
+		});
 		let countdown: ReturnType<typeof setInterval> | null = null;
 		let redirectTimer: ReturnType<typeof setTimeout> | null = null;
-		const unsubClosed = store.closed.subscribe((isClosed) => {
-			if (!isClosed || closed) return;
-			closed = true;
+		let exitStarted = false;
+		const beginExit = () => {
+			if (exitStarted) return;
+			exitStarted = true;
 			redirectIn = CLOSE_REDIRECT_SECONDS;
 			countdown = setInterval(() => {
 				redirectIn = Math.max(0, redirectIn - 1);
 			}, 1000);
 			redirectTimer = setTimeout(leaveClosedRoom, CLOSE_REDIRECT_SECONDS * 1000);
+		};
+		const unsubClosed = store.closed.subscribe((isClosed) => {
+			if (!isClosed || closed) return;
+			closed = true;
+			beginExit();
+		});
+		const unsubKicked = store.kicked.subscribe((wasKicked) => {
+			if (!wasKicked || kicked) return;
+			kicked = true;
+			beginExit();
 		});
 		return () => {
 			unsubMessages();
 			unsubEvent();
 			unsubMembers();
+			unsubOwner();
 			unsubClosed();
+			unsubKicked();
 			if (countdown) clearInterval(countdown);
 			if (redirectTimer) clearTimeout(redirectTimer);
 		};
@@ -91,7 +115,7 @@
 	});
 
 	function send() {
-		if (closed || !chat || !input.trim()) return;
+		if (closed || kicked || !chat || !input.trim()) return;
 		chat.send(input);
 		input = '';
 	}
@@ -121,6 +145,8 @@
 		address: string;
 		username: string;
 		isMe: boolean;
+		isAdmin: boolean;
+		isOwner: boolean;
 	}
 
 	const partyMembers = $derived.by<PartyMember[]>(() => {
@@ -128,7 +154,9 @@
 		return roster.map((m) => ({
 			address: m.address,
 			username: m.username || shortAddr(m.address),
-			isMe: m.address.toLowerCase() === meKey
+			isMe: m.address.toLowerCase() === meKey,
+			isAdmin: m.is_admin,
+			isOwner: m.address.toLowerCase() === ownerAddress.toLowerCase()
 		}));
 	});
 
@@ -141,6 +169,32 @@
 	const hasMetadata = $derived(
 		Boolean(data.description || data.communicatorLink || data.requirements)
 	);
+
+	async function kickMember(member: PartyMember) {
+		if (kickPending) return;
+		kickPending = true;
+		kickError = null;
+		const body = new FormData();
+		body.set('member_address', member.address);
+		try {
+			const response = await fetch('?/kickMember', { method: 'POST', body });
+			const result = deserialize(await response.text()) as
+				| { type: 'success' }
+				| { type: 'failure'; data?: { error?: string } }
+				| { type: 'error' | 'redirect' };
+			if (result.type === 'success') {
+				kickTarget = null;
+			} else if (result.type === 'failure') {
+				kickError = result.data?.error ?? 'Failed to kick player';
+			} else {
+				kickError = 'Failed to kick player';
+			}
+		} catch {
+			kickError = 'Server error';
+		} finally {
+			kickPending = false;
+		}
+	}
 </script>
 
 <svelte:head>
@@ -165,6 +219,20 @@
 								</span>
 								<span class="member-addr">{shortAddr(m.address)}</span>
 							</div>
+							{#if data.isAdmin && !m.isMe && !m.isAdmin}
+								<button
+									class="kick-button"
+									type="button"
+									title="Kick player"
+									aria-label="Kick {m.username}"
+									onclick={() => {
+										kickError = null;
+										kickTarget = m;
+									}}
+								>
+									✕
+								</button>
+							{/if}
 						</li>
 					{/each}
 				</ul>
@@ -236,7 +304,7 @@
 				<div class="event-slot">
 					<RoomEvent
 						{event}
-						isCreator={data.isCreator}
+						isCreator={ownerAddress.toLowerCase() === data.address.toLowerCase()}
 						isMember={true}
 						viewerAddress={data.address}
 						members={eventMembers}
@@ -255,15 +323,22 @@
 						{:else}
 							<ul class="msg-list">
 								{#each messages as msg (msg.id)}
-									{@const mine = isMine(msg.sender_address)}
-									<li class="msg-row" class:mine class:other={!mine}>
-										<article class="msg" class:mine class:other={!mine}>
+									{@const system = msg.kind === 'system'}
+									{@const mine = !system && isMine(msg.sender_address)}
+									<li class="msg-row" class:mine class:other={!mine && !system} class:system>
+										<article class="msg" class:mine class:other={!mine && !system} class:system>
 											<div class="msg-meta">
 												<span class="sender small-caps">
-													{mine ? 'You' : msg.sender_username || shortAddr(msg.sender_address)}
+													{system
+														? 'System'
+														: mine
+															? 'You'
+															: msg.sender_username || shortAddr(msg.sender_address)}
 												</span>
-												<span class="sep" aria-hidden="true">·</span>
-												<span class="addr">{shortAddr(msg.sender_address)}</span>
+												{#if !system}
+													<span class="sep" aria-hidden="true">·</span>
+													<span class="addr">{shortAddr(msg.sender_address)}</span>
+												{/if}
 												<span class="sep" aria-hidden="true">·</span>
 												<span class="time">{fmtTime(msg.created_at)}</span>
 											</div>
@@ -287,16 +362,16 @@
 							type="text"
 							bind:value={input}
 							onkeydown={onKey}
-							placeholder={closed ? 'Room closed' : 'Speak…'}
+							placeholder={closed ? 'Room closed' : kicked ? 'Removed from room' : 'Speak…'}
 							maxlength={1000}
 							autocomplete="off"
-							disabled={closed}
+							disabled={closed || kicked}
 						/>
 						<OrnateButton
 							type="submit"
 							variant="primary"
 							size="md"
-							disabled={closed || !input.trim()}
+							disabled={closed || kicked || !input.trim()}
 						>
 							Transmit
 						</OrnateButton>
@@ -306,6 +381,28 @@
 		</InnerPanel>
 	</div>
 </section>
+
+{#if kicked}
+	<SystemDialog
+		open={true}
+		title="Removed from Lobby"
+		tone="blood"
+		modal
+		closeable={false}
+		width="460px"
+	>
+		<p class="closed-text">An administrator removed you from this room.</p>
+		<p class="closed-sub">
+			You may join again. Returning to the rooms list in {redirectIn}
+			{redirectIn === 1 ? 'second' : 'seconds'}…
+		</p>
+		{#snippet footer()}
+			<OrnateButton variant="primary" size="md" onclick={leaveClosedRoom}>
+				Return to Rooms
+			</OrnateButton>
+		{/snippet}
+	</SystemDialog>
+{/if}
 
 {#if closed}
 	<SystemDialog
@@ -325,6 +422,48 @@
 			<OrnateButton variant="primary" size="md" onclick={leaveClosedRoom}
 				>Return to Rooms</OrnateButton
 			>
+		{/snippet}
+	</SystemDialog>
+{/if}
+
+{#if kickTarget}
+	{@const target = kickTarget}
+	<SystemDialog
+		open={true}
+		title="Kick Player"
+		tone="blood"
+		modal
+		width="460px"
+		onclose={() => {
+			if (!kickPending) kickTarget = null;
+		}}
+	>
+		<p class="closed-text">
+			Remove <strong>{target.username}</strong> from this room and disconnect their active session?
+		</p>
+		{#if target.isOwner}
+			<p class="owner-warning">You will become the new owner of this room.</p>
+		{/if}
+		{#if kickError}
+			<p class="kick-error" role="alert">{kickError}</p>
+		{/if}
+		{#snippet footer()}
+			<OrnateButton
+				variant="ghost"
+				size="md"
+				disabled={kickPending}
+				onclick={() => (kickTarget = null)}
+			>
+				Cancel
+			</OrnateButton>
+			<OrnateButton
+				variant="danger"
+				size="md"
+				disabled={kickPending}
+				onclick={() => kickMember(target)}
+			>
+				{kickPending ? 'Kicking…' : 'Kick Player'}
+			</OrnateButton>
 		{/snippet}
 	</SystemDialog>
 {/if}
@@ -420,6 +559,35 @@
 		font-size: 0.65rem;
 		color: var(--bone-dim);
 		letter-spacing: 0.04em;
+	}
+
+	.kick-button {
+		appearance: none;
+		width: 24px;
+		height: 24px;
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		padding: 0;
+		border: 1px solid var(--stone-6);
+		background: rgba(80, 12, 12, 0.3);
+		color: var(--blood-bright);
+		font-family: var(--font-mono);
+		font-size: 0.72rem;
+		cursor: pointer;
+		opacity: 0.72;
+		transition:
+			opacity 140ms ease,
+			border-color 140ms ease,
+			background 140ms ease;
+	}
+
+	.kick-button:hover,
+	.kick-button:focus-visible {
+		opacity: 1;
+		border-color: var(--blood-bright);
+		background: rgba(120, 18, 18, 0.45);
+		outline: none;
 	}
 
 	/* --- Main column --- */
@@ -677,6 +845,21 @@
 		background: rgba(227, 188, 116, 0.22);
 	}
 
+	.msg.system {
+		border-left: 2px solid var(--blood-bright);
+		background: rgba(120, 18, 18, 0.12);
+		text-align: center;
+	}
+
+	.msg.system .msg-meta {
+		justify-content: center;
+		width: 100%;
+	}
+
+	.msg.system .sender {
+		color: var(--blood-bright);
+	}
+
 	.msg-meta {
 		display: inline-flex;
 		flex-wrap: wrap;
@@ -788,5 +971,26 @@
 		font-size: 0.82rem;
 		color: var(--bone-muted);
 		letter-spacing: 0.03em;
+	}
+
+	.owner-warning,
+	.kick-error {
+		margin: 0.8rem 0 0;
+		padding: 0.65rem 0.75rem;
+		font-family: var(--font-mono);
+		font-size: 0.78rem;
+		line-height: 1.45;
+	}
+
+	.owner-warning {
+		border-left: 2px solid var(--gold-base);
+		background: var(--gold-faint);
+		color: var(--gold-lit);
+	}
+
+	.kick-error {
+		border-left: 2px solid var(--blood-bright);
+		background: rgba(120, 18, 18, 0.14);
+		color: #ffd9d9;
 	}
 </style>


### PR DESCRIPTION
## Summary

- Adds admin-only kick controls with confirmation and realtime updates.
- Disconnects kicked users while allowing them to rejoin.
- Transfers room ownership to the acting admin when required.
- Adds Admin Preview without joining or occupying a slot.
- Improves WebSocket resilience and room-list panel layout.

## Verification

- Backend: 129 tests passed
- Frontend: check, lint and production build passed

Closes #78