### PR TITLE
feat: cryptographically signed chat messages (#59)

### DIFF
--- a/backend/alembic/versions/c4a9f1e7b6d2_add_message_signature.py
+++ b/backend/alembic/versions/c4a9f1e7b6d2_add_message_signature.py
@@ -1,0 +1,38 @@
+"""add message signature and sent_at
+
+Revision ID: c4a9f1e7b6d2
+Revises: 9c3d2e1f0a4b
+Create Date: 2026-06-18 00:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+import sqlmodel
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "c4a9f1e7b6d2"
+down_revision: str | None = "9c3d2e1f0a4b"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    # Issue #59: EIP-191 signature and the exact client timestamp it covers.
+    # Both nullable so legacy messages stay valid and render as unverified.
+    op.add_column(
+        "message",
+        sa.Column("signature", sqlmodel.sql.sqltypes.AutoString(), nullable=True),
+    )
+    op.add_column(
+        "message",
+        sa.Column("sent_at", sqlmodel.sql.sqltypes.AutoString(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("message", "sent_at")
+    op.drop_column("message", "signature")

--- a/backend/main.py
+++ b/backend/main.py
@@ -1346,6 +1346,50 @@ async def websocket_rooms(websocket: WebSocket, session: SessionDep):
         manager.disconnect(websocket)
 
 
+# Issue #59: chat messages are signed with the sender's BIP39-derived key
+# (EIP-191 personal_sign) so authorship is verifiable end-to-end rather than
+# trusted on the JWT alone. Reject timestamps drifting more than this from the
+# server clock to blunt replay of captured signatures.
+CHAT_SIGNATURE_SKEW_SECONDS = 120
+
+
+def _chat_signing_message(room_name: str, content: str, sent_at: str) -> str:
+    """Canonical text the client signs and the server reconstructs.
+
+    Must stay byte-for-byte in sync with the frontend builder in
+    ``frontend/src/lib/signing.ts``.
+    """
+    return (
+        "PlayLink signed chat message\n"
+        f"room={room_name}\n"
+        f"sent_at={sent_at}\n"
+        f"content={content}"
+    )
+
+
+def _verify_chat_signature(
+    room_name: str, content: str, sent_at: str, signature: str, address: str
+) -> bool:
+    """True iff ``signature`` was produced by ``address`` over the canonical
+    payload and ``sent_at`` is within the allowed clock skew."""
+    try:
+        signed_at = datetime.fromisoformat(sent_at)
+    except (ValueError, TypeError):
+        return False
+    if signed_at.tzinfo is None:
+        signed_at = signed_at.replace(tzinfo=UTC)
+    drift = abs((datetime.now(UTC) - signed_at).total_seconds())
+    if drift > CHAT_SIGNATURE_SKEW_SECONDS:
+        return False
+
+    message = encode_defunct(text=_chat_signing_message(room_name, content, sent_at))
+    try:
+        recovered = Account.recover_message(message, signature=signature)
+    except Exception:
+        return False
+    return recovered.lower() == address.lower()
+
+
 def _msg_dict(msg: Message, sender_username: str) -> dict:
     payload = {
         "id": msg.id,
@@ -1353,6 +1397,9 @@ def _msg_dict(msg: Message, sender_username: str) -> dict:
         "sender_username": sender_username,
         "content": msg.content,
         "created_at": _iso(msg.created_at),
+        "signature": msg.signature,
+        "sent_at": msg.sent_at,
+        "verified": msg.signature is not None,
     }
     if msg.sender_address == SYSTEM_SENDER_ADDRESS:
         payload["kind"] = "system"
@@ -1456,10 +1503,30 @@ async def websocket_chat(
             if not content or len(content) > 1000:
                 continue
 
+            # Issue #59: when a signature is supplied it must verify against the
+            # connected identity, otherwise the message is rejected outright
+            # (never stored or broadcast). A missing signature is a legacy /
+            # no-key client and is accepted as unverified.
+            raw_signature = data.get("signature")
+            signature: str | None = None
+            sent_at: str | None = None
+            if raw_signature:
+                signature = str(raw_signature)
+                sent_at = str(data.get("sent_at", ""))
+                if not _verify_chat_signature(
+                    room_name, content, sent_at, signature, address
+                ):
+                    await websocket.send_text(
+                        json.dumps({"type": "error", "detail": "signature_invalid"})
+                    )
+                    continue
+
             msg = Message(
                 room_id=room.id,
                 sender_address=address,
                 content=content,
+                signature=signature,
+                sent_at=sent_at,
             )
             session.add(msg)
             session.commit()

--- a/backend/main.py
+++ b/backend/main.py
@@ -1374,7 +1374,7 @@ def _verify_chat_signature(
     payload and ``sent_at`` is within the allowed clock skew."""
     try:
         signed_at = datetime.fromisoformat(sent_at)
-    except (ValueError, TypeError):
+    except ValueError, TypeError:
         return False
     if signed_at.tzinfo is None:
         signed_at = signed_at.replace(tzinfo=UTC)

--- a/backend/models.py
+++ b/backend/models.py
@@ -38,6 +38,11 @@ class Message(SQLModel, table=True):
     sender_address: str = Field(index=True)
     content: str
     created_at: datetime = Field(default_factory=lambda: datetime.now(UTC), index=True)
+    # Issue #59: EIP-191 signature over the canonical payload and the exact
+    # client-supplied ISO-8601 timestamp that was signed. Both NULL for legacy
+    # (pre-signing) messages, which stay valid but render as unverified.
+    signature: str | None = Field(default=None)
+    sent_at: str | None = Field(default=None)
 
 
 class RsvpStatus(StrEnum):

--- a/backend/tests/test_chat.py
+++ b/backend/tests/test_chat.py
@@ -3,6 +3,8 @@ from datetime import UTC, datetime, timedelta
 
 import jwt
 import pytest
+from eth_account import Account
+from eth_account.messages import encode_defunct
 from fastapi.testclient import TestClient
 from sqlmodel import Session, select
 from starlette.websockets import WebSocketDisconnect
@@ -149,3 +151,139 @@ def test_chat_drops_oversize_and_empty(client: TestClient, session: Session):
 
     rows = _all(session, select(Message))
     assert [r.content for r in rows] == ["kept"]
+
+
+# --- Cryptographically signed messages (issue #59) ---------------------------
+
+
+def _canonical_chat(room: str, content: str, sent_at: str) -> str:
+    """Mirror of the backend's canonical signing payload. Must stay in sync."""
+    return (
+        "PlayLink signed chat message\n"
+        f"room={room}\n"
+        f"sent_at={sent_at}\n"
+        f"content={content}"
+    )
+
+
+def _sign_chat(acct, room: str, content: str, sent_at: str) -> str:
+    message = encode_defunct(text=_canonical_chat(room, content, sent_at))
+    return acct.sign_message(message).signature.hex()
+
+
+def _seed_signed_member(session: Session, room_name: str):
+    """Seed a room whose sole member owns a real keypair; return (acct, token)."""
+    acct = Account.create()
+    _seed_room_and_users(session, room_name, [acct.address])
+    return acct, _mint_token(acct.address)
+
+
+def test_chat_signed_message_is_verified(client: TestClient, session: Session):
+    acct, token = _seed_signed_member(session, "vault")
+    sent_at = datetime.now(UTC).isoformat()
+    content = "signed hello"
+    sig = _sign_chat(acct, "vault", content, sent_at)
+
+    with client.websocket_connect(f"/ws/rooms/vault/chat?token={token}") as ws:
+        ws.receive_json()  # history
+        ws.send_json({"content": content, "sent_at": sent_at, "signature": sig})
+        frame = ws.receive_json()
+
+    assert frame["type"] == "message"
+    msg = frame["message"]
+    assert msg["content"] == content
+    assert msg["verified"] is True
+    assert msg["signature"] == sig
+    assert msg["sent_at"] == sent_at
+
+    rows = _all(session, select(Message))
+    assert len(rows) == 1
+    assert rows[0].signature == sig
+    assert rows[0].sent_at == sent_at
+
+
+def test_chat_rejects_tampered_content(client: TestClient, session: Session):
+    acct, token = _seed_signed_member(session, "tamper")
+    sent_at = datetime.now(UTC).isoformat()
+    sig = _sign_chat(acct, "tamper", "original", sent_at)
+
+    with client.websocket_connect(f"/ws/rooms/tamper/chat?token={token}") as ws:
+        ws.receive_json()  # history
+        ws.send_json({"content": "modified", "sent_at": sent_at, "signature": sig})
+        frame = ws.receive_json()
+
+    assert frame["type"] == "error"
+    assert frame["detail"] == "signature_invalid"
+    assert _all(session, select(Message)) == []
+
+
+def test_chat_rejects_wrong_signer(client: TestClient, session: Session):
+    acct, token = _seed_signed_member(session, "imposter")
+    attacker = Account.create()
+    sent_at = datetime.now(UTC).isoformat()
+    content = "not really me"
+    sig = _sign_chat(attacker, "imposter", content, sent_at)
+
+    with client.websocket_connect(f"/ws/rooms/imposter/chat?token={token}") as ws:
+        ws.receive_json()  # history
+        ws.send_json({"content": content, "sent_at": sent_at, "signature": sig})
+        frame = ws.receive_json()
+
+    assert frame["type"] == "error"
+    assert frame["detail"] == "signature_invalid"
+    assert _all(session, select(Message)) == []
+
+
+def test_chat_rejects_stale_timestamp(client: TestClient, session: Session):
+    acct, token = _seed_signed_member(session, "stale")
+    sent_at = (datetime.now(UTC) - timedelta(minutes=10)).isoformat()
+    content = "old news"
+    sig = _sign_chat(acct, "stale", content, sent_at)
+
+    with client.websocket_connect(f"/ws/rooms/stale/chat?token={token}") as ws:
+        ws.receive_json()  # history
+        ws.send_json({"content": content, "sent_at": sent_at, "signature": sig})
+        frame = ws.receive_json()
+
+    assert frame["type"] == "error"
+    assert frame["detail"] == "signature_invalid"
+    assert _all(session, select(Message)) == []
+
+
+def test_chat_unsigned_message_is_unverified(client: TestClient, session: Session):
+    _, token = _seed_signed_member(session, "legacy")
+
+    with client.websocket_connect(f"/ws/rooms/legacy/chat?token={token}") as ws:
+        ws.receive_json()  # history
+        ws.send_json({"content": "plain text"})
+        frame = ws.receive_json()
+
+    msg = frame["message"]
+    assert msg["content"] == "plain text"
+    assert msg["verified"] is False
+    assert msg["signature"] is None
+
+    rows = _all(session, select(Message))
+    assert len(rows) == 1
+    assert rows[0].signature is None
+
+
+def test_chat_history_includes_signature(client: TestClient, session: Session):
+    acct, token = _seed_signed_member(session, "archive")
+    sent_at = datetime.now(UTC).isoformat()
+    content = "for the record"
+    sig = _sign_chat(acct, "archive", content, sent_at)
+
+    with client.websocket_connect(f"/ws/rooms/archive/chat?token={token}") as ws:
+        ws.receive_json()  # history
+        ws.send_json({"content": content, "sent_at": sent_at, "signature": sig})
+        ws.receive_json()  # echoed message
+
+    with client.websocket_connect(f"/ws/rooms/archive/chat?token={token}") as ws:
+        history = ws.receive_json()
+
+    assert history["type"] == "history"
+    assert len(history["messages"]) == 1
+    hm = history["messages"][0]
+    assert hm["verified"] is True
+    assert hm["signature"] == sig

--- a/backend/tests/test_helpers.py
+++ b/backend/tests/test_helpers.py
@@ -88,6 +88,9 @@ def test_msg_dict_keeps_public_chat_payload_shape():
         "sender_username": "alice",
         "content": "hello",
         "created_at": "2026-01-02T03:04:05+00:00",
+        "signature": None,
+        "sent_at": None,
+        "verified": False,
     }
 
 

--- a/backend/tests/test_room_events.py
+++ b/backend/tests/test_room_events.py
@@ -694,12 +694,17 @@ def test_chat_history_and_message_frames_unchanged(
         # No new top-level keys leaked into existing frames.
         assert set(msg.keys()) == {"type", "message"}
         assert msg["type"] == "message"
+        # Issue #59 added signature/sent_at/verified; an unsigned message
+        # carries them as null/false.
         assert set(msg["message"].keys()) == {
             "id",
             "sender_address",
             "sender_username",
             "content",
             "created_at",
+            "signature",
+            "sent_at",
+            "verified",
         }
 
 

--- a/frontend/src/lib/auth.ts
+++ b/frontend/src/lib/auth.ts
@@ -1,5 +1,6 @@
 import { ethers, Mnemonic, HDNodeWallet } from 'ethers';
 import { env } from '$env/dynamic/public';
+import { saveSigningKey } from '$lib/signingKey';
 
 /**
  * Derives a cryptographic identity (private/public key pair) from a 12-word mnemonic.
@@ -39,6 +40,10 @@ export async function authenticate(mnemonicPhrase: string) {
 
 	const identity = getIdentityFromMnemonic(mnemonicPhrase);
 	const publicAddress = identity.address;
+
+	// Issue #59: keep the key for this tab session so chat messages can be
+	// signed without re-entering the phrase. Cleared on logout / tab close.
+	saveSigningKey(identity.privateKey);
 
 	// Phase 1: Request Challenge
 	// Note: We'll keep using searchParams as established in the backend previously,

--- a/frontend/src/lib/chatStore.ts
+++ b/frontend/src/lib/chatStore.ts
@@ -1,6 +1,7 @@
 import { browser } from '$app/environment';
 import { env } from '$env/dynamic/public';
 import { writable, type Readable } from 'svelte/store';
+import { signChatMessage, type ChatSigner } from '$lib/signing';
 
 // ---------- Public types ----------
 
@@ -11,6 +12,12 @@ export interface ChatMessage {
 	content: string;
 	created_at: string;
 	kind?: 'user' | 'system';
+	/** EIP-191 signature over the canonical payload, or null for legacy/unsigned. */
+	signature?: string | null;
+	/** Exact client timestamp that was signed, or null for legacy/unsigned. */
+	sent_at?: string | null;
+	/** True when the server recovered a valid signer for this message. */
+	verified?: boolean;
 }
 
 export interface RoomMember {
@@ -77,6 +84,12 @@ interface MemberKickedFrame {
 	ownership_transferred: boolean;
 }
 
+/** Server rejected an inbound message (e.g. a signature that failed to verify). */
+interface ErrorFrame {
+	type: 'error';
+	detail: string;
+}
+
 type ChatFrame =
 	| HistoryFrame
 	| MessageFrame
@@ -84,7 +97,8 @@ type ChatFrame =
 	| RsvpUpdateFrame
 	| RosterUpdateFrame
 	| RoomClosedFrame
-	| MemberKickedFrame;
+	| MemberKickedFrame
+	| ErrorFrame;
 
 // ---------- Frame validation ----------
 
@@ -97,7 +111,10 @@ function isChatMessage(value: unknown): value is ChatMessage {
 		typeof m.sender_username === 'string' &&
 		typeof m.content === 'string' &&
 		typeof m.created_at === 'string' &&
-		(m.kind === undefined || m.kind === 'user' || m.kind === 'system')
+		(m.kind === undefined || m.kind === 'user' || m.kind === 'system') &&
+		(m.signature === undefined || m.signature === null || typeof m.signature === 'string') &&
+		(m.sent_at === undefined || m.sent_at === null || typeof m.sent_at === 'string') &&
+		(m.verified === undefined || typeof m.verified === 'boolean')
 	);
 }
 
@@ -179,6 +196,9 @@ function parseFrame(raw: string): ChatFrame | null {
 	) {
 		return f as unknown as MemberKickedFrame;
 	}
+	if (f.type === 'error' && typeof f.detail === 'string') {
+		return { type: 'error', detail: f.detail };
+	}
 	return null;
 }
 
@@ -197,7 +217,7 @@ export interface ChatStore {
 	owner: Readable<string>;
 	/** Becomes `true` when this client is removed from the room. */
 	kicked: Readable<boolean>;
-	send(content: string): void;
+	send(content: string): Promise<void>;
 	destroy(): void;
 }
 
@@ -210,6 +230,11 @@ export interface CreateChatStoreOptions {
 	initialOwner?: string;
 	/** Address represented by this browser session. */
 	currentAddress?: string;
+	/**
+	 * Key used to sign outgoing messages (issue #59). When absent, messages are
+	 * sent unsigned and the server marks them unverified.
+	 */
+	signer?: ChatSigner | null;
 }
 
 export function createChatStore(
@@ -297,6 +322,11 @@ export function createChatStore(
 						if (reconnectTimeout) clearTimeout(reconnectTimeout);
 					}
 					break;
+				case 'error':
+					// The server rejected our last message (e.g. signature mismatch
+					// or stale timestamp). It is never stored or broadcast.
+					console.warn('Chat message rejected:', frame.detail);
+					break;
 			}
 		};
 
@@ -335,9 +365,26 @@ export function createChatStore(
 		closed: { subscribe: closed.subscribe },
 		owner: { subscribe: owner.subscribe },
 		kicked: { subscribe: kicked.subscribe },
-		send(content: string) {
+		async send(content: string) {
 			const trimmed = content.trim();
 			if (!trimmed || !ws || ws.readyState !== WebSocket.OPEN) return;
+
+			// Issue #59: sign the canonical payload so the server can verify
+			// authorship. A signing failure degrades to an unsigned (unverified)
+			// message rather than dropping it.
+			if (options.signer) {
+				const sentAt = new Date().toISOString();
+				try {
+					const signature = await signChatMessage(options.signer, roomName, trimmed, sentAt);
+					if (!ws || ws.readyState !== WebSocket.OPEN) return;
+					ws.send(JSON.stringify({ content: trimmed, sent_at: sentAt, signature }));
+					return;
+				} catch (e) {
+					console.error('Message signing failed; sending unsigned', e);
+				}
+			}
+
+			if (!ws || ws.readyState !== WebSocket.OPEN) return;
 			ws.send(JSON.stringify({ content: trimmed }));
 		},
 		destroy() {

--- a/frontend/src/lib/signing.ts
+++ b/frontend/src/lib/signing.ts
@@ -1,0 +1,34 @@
+/**
+ * Per-message cryptographic signing (issue #59).
+ *
+ * Chat messages are signed with the sender's BIP39-derived key (EIP-191
+ * `personal_sign`) so the backend can recover the signer and prove authorship
+ * instead of trusting the JWT alone.
+ */
+
+/** Anything that can produce an EIP-191 signature — `HDNodeWallet` and
+ *  `ethers.Wallet` both satisfy this. */
+export interface ChatSigner {
+	signMessage(message: string): Promise<string>;
+}
+
+/**
+ * Canonical text that is signed for a chat message.
+ *
+ * This MUST stay byte-for-byte identical to the backend builder
+ * `_chat_signing_message` in `backend/main.py`, otherwise recovery fails and
+ * every message is rejected.
+ */
+export function buildChatSigningMessage(room: string, content: string, sentAt: string): string {
+	return `PlayLink signed chat message\nroom=${room}\nsent_at=${sentAt}\ncontent=${content}`;
+}
+
+/** Signs a chat message and returns the EIP-191 signature (0x-hex). */
+export async function signChatMessage(
+	signer: ChatSigner,
+	room: string,
+	content: string,
+	sentAt: string
+): Promise<string> {
+	return signer.signMessage(buildChatSigningMessage(room, content, sentAt));
+}

--- a/frontend/src/lib/signingKey.ts
+++ b/frontend/src/lib/signingKey.ts
@@ -1,0 +1,45 @@
+import { browser } from '$app/environment';
+import { Wallet } from 'ethers';
+
+/**
+ * Session-scoped custody of the message-signing key (issue #59).
+ *
+ * The auth flow derives a wallet from the recovery phrase but otherwise
+ * discards it, keeping only the JWT cookie. To sign every chat message the
+ * private key must remain available on the chat route, so we stash it in
+ * `sessionStorage`: it survives reloads within the tab and is cleared when the
+ * tab closes (or on logout). This is the realistic model for a self-custody
+ * web wallet without a browser extension; the key is XSS-exposed, the same
+ * exposure class as any in-page secret.
+ */
+const STORAGE_KEY = 'playlink.sk';
+
+/** Persists the signing key for the current tab session. */
+export function saveSigningKey(privateKey: string): void {
+	if (!browser) return;
+	try {
+		sessionStorage.setItem(STORAGE_KEY, privateKey);
+	} catch (e) {
+		console.error('Could not persist signing key', e);
+	}
+}
+
+/** Returns a signer for the stored key, or null when none is available. */
+export function loadSigner(): Wallet | null {
+	if (!browser) return null;
+	const privateKey = sessionStorage.getItem(STORAGE_KEY);
+	if (!privateKey) return null;
+	try {
+		return new Wallet(privateKey);
+	} catch (e) {
+		console.error('Stored signing key is invalid; discarding', e);
+		sessionStorage.removeItem(STORAGE_KEY);
+		return null;
+	}
+}
+
+/** Forgets the signing key (called on logout). */
+export function clearSigningKey(): void {
+	if (!browser) return;
+	sessionStorage.removeItem(STORAGE_KEY);
+}

--- a/frontend/src/routes/auth/+page.svelte
+++ b/frontend/src/routes/auth/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { generateMnemonic, authenticate } from '$lib/auth';
+	import { clearSigningKey } from '$lib/signingKey';
 	import MnemonicInput from '$lib/components/MnemonicInput.svelte';
 	import { enhance, deserialize } from '$app/forms';
 	import { invalidateAll } from '$app/navigation';
@@ -148,6 +149,7 @@
 						action="?/logout"
 						class="logout-form"
 						use:enhance={() => {
+							clearSigningKey();
 							return async ({ update }) => {
 								await update();
 								await invalidateAll();

--- a/frontend/src/routes/rooms/[name]/+page.svelte
+++ b/frontend/src/routes/rooms/[name]/+page.svelte
@@ -10,6 +10,7 @@
 		type RoomEventState,
 		type RoomMember
 	} from '$lib/chatStore';
+	import { loadSigner } from '$lib/signingKey';
 	import InnerPanel from '$lib/components/chrome/InnerPanel.svelte';
 	import SectionTitle from '$lib/components/chrome/SectionTitle.svelte';
 	import OrnateButton from '$lib/components/chrome/OrnateButton.svelte';
@@ -77,7 +78,10 @@
 			initialEvent: data.event,
 			initialMembers: data.members,
 			initialOwner: data.createdBy,
-			currentAddress: data.address
+			currentAddress: data.address,
+			// Sign outgoing messages when this tab still holds the session key
+			// (issue #59). Falls back to unsigned/unverified when it doesn't.
+			signer: loadSigner()
 		});
 		chat = store;
 		const unsubMessages = store.messages.subscribe(async (m) => {
@@ -134,8 +138,10 @@
 
 	function send() {
 		if (closed || kicked || !chat || !input.trim()) return;
-		chat.send(input);
+		const text = input;
 		input = '';
+		// Signing is async; fire and forget so the input clears immediately.
+		void chat.send(text);
 	}
 
 	function onKey(e: KeyboardEvent) {
@@ -424,6 +430,17 @@
 													{/if}
 													<span class="sep" aria-hidden="true">·</span>
 													<span class="time">{fmtTime(msg.created_at)}</span>
+													{#if msg.verified}
+														<span class="sep" aria-hidden="true">·</span>
+														<span
+															class="verified small-caps"
+															title="Cryptographically signed by {shortAddr(
+																msg.sender_address
+															)} and verified by the server"
+														>
+															✓ Verified
+														</span>
+													{/if}
 												</div>
 												<div class="content">{msg.content}</div>
 											</article>
@@ -1051,6 +1068,15 @@
 		color: var(--bone-dim);
 		font-size: 0.65rem;
 		letter-spacing: 0.04em;
+	}
+
+	.verified {
+		font-family: var(--font-display);
+		color: var(--gold-lit);
+		font-size: 0.62rem;
+		letter-spacing: var(--track-loose);
+		white-space: nowrap;
+		cursor: help;
 	}
 
 	.content {


### PR DESCRIPTION
Closes #59.

Applies the same wallet-crypto used for auth to per-message authorship: each chat message is signed client-side with the user's BIP39-derived key (EIP-191 `personal_sign` via ethers) and verified server-side with `eth_account`, so authorship no longer rests on the JWT alone.

## Backend
- On WS receive, recover the signer and compare to the connected identity. Reject (never store/broadcast, emit an `error` frame) on signature mismatch, wrong signer, or `sent_at` skew > ±2 min (replay protection).
- `Message` gains nullable `signature` + `sent_at`; broadcast/history payloads expose `verified` (`signature is not None`).
- Alembic migration adds both columns as nullable, so legacy messages keep working as unverified.

## Frontend
- The signing key is kept in `sessionStorage` for the tab session (cleared on logout) so messages can be signed without re-entering the phrase.
- `chatStore` signs the canonical payload before sending; a missing key degrades gracefully to an unsigned (unverified) message.
- Verified messages render a "✓ Verified" badge.

## Verification
- Backend: 135 tests pass (6 new chat-signing tests: verified / tampered / wrong-signer / stale / legacy-unverified / history), `ruff` clean, migration applies up+down.
- Frontend: `svelte-check` 0 errors, `eslint` + `prettier` clean.
- Cross-language interop checked: an ethers-signed message recovers to the same address with `eth_account` over the shared canonical string.

### Note
The canonical signing string is duplicated in `frontend/src/lib/signing.ts` and `backend/main.py` (`_chat_signing_message`) and must stay byte-for-byte in sync.