### PR TITLE
ci: validate Alembic migrations against Postgres

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -49,6 +49,46 @@ jobs:
                   DATABASE_URL: sqlite:///
                   JWT_SECRET: ci-test-secret-at-least-thirty-two-chars
 
+    backend-migrations:
+        runs-on: ubuntu-latest
+        services:
+            postgres:
+                image: postgres:18-alpine
+                env:
+                    POSTGRES_USER: playlink
+                    POSTGRES_PASSWORD: playlink
+                    POSTGRES_DB: playlink
+                ports:
+                    - 5432:5432
+                options: >-
+                    --health-cmd "pg_isready -U playlink"
+                    --health-interval 10s
+                    --health-timeout 5s
+                    --health-retries 5
+        env:
+            DATABASE_URL: postgresql+psycopg://playlink:playlink@localhost:5432/playlink
+        steps:
+            - uses: actions/checkout@v6
+            - name: Install uv
+              uses: astral-sh/setup-uv@v7
+              with:
+                  version: "latest"
+                  enable-cache: true
+            - name: Set up Python
+              run: uv python install 3.14
+            - name: Install dependencies
+              run: uv sync --dev
+              working-directory: backend
+            - name: Apply migrations to a clean Postgres
+              run: uv run alembic upgrade head
+              working-directory: backend
+            - name: Round-trip last migration (downgrade -1, upgrade head)
+              run: uv run alembic downgrade -1 && uv run alembic upgrade head
+              working-directory: backend
+            - name: Detect model/migration drift
+              run: uv run alembic check
+              working-directory: backend
+
     frontend-lint:
         runs-on: ubuntu-latest
         steps:
@@ -74,7 +114,7 @@ jobs:
               run: docker compose build
 
     deploy:
-        needs: [backend-lint, backend-test, frontend-lint, build-test]
+        needs: [backend-lint, backend-test, backend-migrations, frontend-lint, build-test]
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         runs-on: ubuntu-latest
         environment: production


### PR DESCRIPTION
Closes #60.

Adds a `backend-migrations` CI job that runs the Alembic migrations against a real Postgres service container (`postgres:18-alpine`, same as prod), so Postgres-specific migration bugs are caught in CI instead of at deploy time.

Steps (all hard gates):
- `alembic upgrade head` on a clean Postgres database
- round-trip: `alembic downgrade -1 && alembic upgrade head`
- `alembic check` for model/migration drift

The job is added to `deploy.needs`, so a broken migration blocks deploy.

Verified locally against `postgres:18-alpine`: upgrade, round-trip and `alembic check` all pass (`No new upgrade operations detected`).